### PR TITLE
fix: chrome path in `PATH` not detected when is last entry

### DIFF
--- a/DrissionPage/easy_set.py
+++ b/DrissionPage/easy_set.py
@@ -340,20 +340,18 @@ def get_chrome_path(ini_path=None,
     # -----------从系统变量中获取--------------
     if from_system_path:
         try:
-            paths = popen('set path').read().lower()
+            paths = [i for i in os.environ['PATH'].split(';') if i != ""]
+            chrome_paths = [i for i in paths if "chrome" in i]
         except:
             return None
-        r = search(r'[^;]*chrome[^;\n]*', paths)
 
-        if r:
-            path = Path(r.group(0)) if 'chrome.exe' in r.group(0) else Path(r.group(0)) / 'chrome.exe'
+        if chrome_paths:
+            path = Path(chrome_paths[0]) if 'chrome.exe' in chrome_paths[0] else (Path(chrome_paths[0]) / 'chrome.exe')
 
             if path.exists():
                 if show_msg:
                     print('系统变量中', end='')
                 return str(path)
-
-        paths = paths.split(';')
 
         for path in paths:
             path = Path(path) / 'chrome.exe'

--- a/DrissionPage/easy_set.py
+++ b/DrissionPage/easy_set.py
@@ -343,7 +343,7 @@ def get_chrome_path(ini_path=None,
             paths = popen('set path').read().lower()
         except:
             return None
-        r = search(r'[^;]*chrome[^;]*', paths)
+        r = search(r'[^;]*chrome[^;\n]*', paths)
 
         if r:
             path = Path(r.group(0)) if 'chrome.exe' in r.group(0) else Path(r.group(0)) / 'chrome.exe'


### PR DESCRIPTION
示例：
```python
In [9]: paths = popen('set path').read().lower()
# paths = '...;c:\\users\\user\\appdata\\local\\google\\chrome\\application\\chrome.exe\npathext=.com;.exe;.bat;.cmd;.vbs;.vbe;.js;.jse;.wsf;.wsh;.msc;.py;.pyw;.jar\n'
In [11]: search(r'[^;]*chrome[^;]*', paths)
Out[11]: <re.Match object; span=(1719, 1805), match='c:\\users\\user\\appdata\\local\\google\>
In [12]: r=search(r'[^;]*chrome[^;]*', paths)
In [13]: path = Path(r.group(0)) if 'chrome.exe' in r.group(0) else Path(r.group(0)) / 'chrome.exe'
Out[14]: WindowsPath('c:/users/user/appdata/local/google/chrome/application/chrome.exe\npathext=.com')
```

以及直接调用`popen`有点不优雅，正常不该用`os.environ`的吗……