### PR TITLE
Improve developer experience when using Listener

### DIFF
--- a/DrissionPage/_units/listener.py
+++ b/DrissionPage/_units/listener.py
@@ -15,7 +15,7 @@ from requests.structures import CaseInsensitiveDict
 
 from .._base.driver import Driver
 from .._functions.settings import Settings
-from ..errors import WaitTimeoutError
+from ..errors import WaitTimeoutError, BrowserConnectError
 
 
 class Listener(object):
@@ -110,7 +110,10 @@ class Listener(object):
         if self.listening:
             return
 
-        self._driver = Driver(self._target_id, 'page', self._address)
+        try:
+            self._driver = Driver(self._target_id, 'page', self._address)
+        except ConnectionRefusedError:
+            raise BrowserConnectError('Websocket连接错误。\n请确保浏览器没有被过早关闭。')
         self._driver.run('Network.enable')
 
         self._set_callback()
@@ -185,6 +188,8 @@ class Listener(object):
         if self.listening:
             self.pause()
             self.clear()
+        if self._driver is None:
+            return
         self._driver.stop()
         self._driver = None
 


### PR DESCRIPTION
While using the library, I forgot to remove a line of code that prematurely calls `page.quit()`, which led to some time spent debugging. Therefore, this pull request aims to improve the developer experience and help prevent similar issues in the future.

Let me know if there are some grammar mistakes in the error info as I used a translator for it.

1. Add detailed error information for the listener when there is a `ConnectionRefusedError` when calling `page.listen.start()`.
This is usually caused when the browser is prematurely closed and the WebSocket is unable to connect to the browser.

2. Fix NoneType/AttributeError when the listener did not initialise and `page.listen.stop()` is called.
This happens when the developer calls `page.listen.stop()` in the `finally` block like so:
```py
try:
    page.listen.start()
finally:
    page.listen.stop()
    page.quit()
```
If `page.listen.start()` wasn't called or did not execute properly and `page.listen.stop()` is called later in the code, it will raise the error, `AttributeError: 'NoneType' object has no attribute 'stop'` as `self._driver` is None.

The errors I got as reference:
```
Traceback (most recent call last):
  File "E:\...\main.py", line 56, in __main
    raise e
  File "E:\...\main.py", line 41, in __main
    page.listen.start(
  File "E:\...\venv\Lib\site-packages\DrissionPage\_units\listener.py", line 113, in start
    self._driver = Driver(self._target_id, 'page', self._address)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\...\venv\Lib\site-packages\DrissionPage\_base\driver.py", line 54, in __init__
    self.start()
  File "E:\...\venv\Lib\site-packages\DrissionPage\_base\driver.py", line 202, in start
    self._ws = create_connection(self._websocket_url, enable_multithread=True, suppress_origin=True)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\...\venv\Lib\site-packages\websocket\_core.py", line 646, in create_connection
    websock.connect(url, **options)
  File "E:\...\venv\Lib\site-packages\websocket\_core.py", line 256, in connect
    self.sock, addrs = connect(
                       ^^^^^^^^
  File "E:\...\venv\Lib\site-packages\websocket\_http.py", line 145, in connect
    sock = _open_socket(addrinfo_list, options.sockopt, options.timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\...\venv\Lib\site-packages\websocket\_http.py", line 232, in _open_socket
    raise err
  File "E:\...\venv\Lib\site-packages\websocket\_http.py", line 209, in _open_socket
    sock.connect(address)
ConnectionRefusedError: [WinError 10061] No connection could be made because the target machine actively refused it

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "E:\...\main.py", line 126, in <module>
    main(args=parser.create_arg_parser().parse_args())
  File "E:\...\main.py", line 97, in main
    return __main(
           ^^^^^^^
  File "E:\...\main.py", line 59, in __main
    page.listen.stop()
  File "E:\...\venv\Lib\site-packages\DrissionPage\_units\listener.py", line 188, in stop
    self._driver.stop()
    ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'stop'
```