### PR TITLE
添加is_force_run_browser参数实现强制启动浏览器,解决浏览器无法连接异常

### DIFF
--- a/DrissionPage/_configs/chromium_options.py
+++ b/DrissionPage/_configs/chromium_options.py
@@ -22,6 +22,7 @@ class ChromiumOptions(object):
         self._prefs_to_del = []
         self.clear_file_flags = False
         self._headless = None
+        self.is_force_run_browser = False
 
         if read_file is False:
             ini_path = False

--- a/DrissionPage/_functions/browser.py
+++ b/DrissionPage/_functions/browser.py
@@ -26,9 +26,10 @@ def connect_browser(option):
     """
     address = option.address.replace('localhost', '127.0.0.1').lstrip('http://').lstrip('https://')
     browser_path = option.browser_path
+    is_force_run_browser = option.is_force_run_browser
 
     ip, port = address.split(':')
-    if ip != '127.0.0.1' or port_is_using(ip, port) or option.is_existing_only:
+    if (is_force_run_browser == None or is_force_run_browser == False) and (ip != '127.0.0.1' or port_is_using(ip, port) or option.is_existing_only):
         test_connect(ip, port)
         option._headless = False
         for i in option.arguments:


### PR DESCRIPTION
我遇到的问题是因为在UOS上telnet所有端口都会显示是通的,所以解决方案就是在chrome_option添加一个参数is_force_run_browser,默认False,在connect_browser中添加判断,实现强制启动浏览器

以下是我在CSDN上的文章:
[DrissionPage在UOS中使用时浏览器无法链接](https://wellchang.blog.csdn.net/article/details/141824368?spm=1001.2014.3001.5502)