### PR TITLE
fix memory leak when chromium is dereferenced after quit

### DIFF
--- a/_base/driver.py
+++ b/_base/driver.py
@@ -17,6 +17,7 @@ from websocket import (WebSocketTimeoutException, WebSocketConnectionClosedExcep
 
 from .._functions.settings import Settings as _S
 from ..errors import PageDisconnectedError, BrowserConnectError
+from weakref import proxy as weak_proxy
 
 adapters.DEFAULT_RETRIES = 5
 
@@ -26,7 +27,8 @@ class Driver(object):
         self.id = tab_id
         self.address = address
         self.type = tab_type
-        self.owner = owner
+        # Circular reference caused a memory leak
+        self.owner = weak_proxy(owner) if owner else None
         self.alert_flag = False  # 标记alert出现，跳过一条请求后复原
 
         self._websocket_url = f'ws://{address}/devtools/{tab_type}/{tab_id}'

--- a/_units/downloader.py
+++ b/_units/downloader.py
@@ -13,12 +13,14 @@ from time import sleep, perf_counter
 from DataRecorder.tools import get_usable_path
 
 from .._functions.settings import Settings as _S
+from weakref import proxy as weak_proxy
 
 
 class DownloadManager(object):
 
     def __init__(self, browser):
-        self._browser = browser
+        # Circular reference caused a memory leak
+        self._browser = weak_proxy(browser)
 
         t = TabDownloadSettings('browser')
         t.path = self._browser.download_path


### PR DESCRIPTION
When Chromium is dereferenced in a script, the class is not deleted by the garbage collector.

you can test it with [this code](https://gist.github.com/alex-bouget/6bc2e55216864302df7af903e9822317).

If Chromium is dereferenced before quit, it also cause a memory leak with the callbacks `Target.targetDestroyed` and `Target.targetCreated` but i didn't fixing it.