### PR TITLE
fix: The clicker becomes invalid when the hyperlink breaks on a new line

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/DrissionPage.iml
+++ b/.idea/DrissionPage.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,23 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredBaseClasses">
+        <list>
+          <option value="unittest.TestCase" />
+          <option value="unittest.case.TestCase" />
+          <option value="controllers.utils.breakOff.BreakOff" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="project01.firstproject.firstproject.urls.app01" />
+          <option value="dict.*" />
+          <option value="Day02.dp.cls" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <enabledExtensions>
+      <entry key="MermaidLanguageExtension" value="false" />
+      <entry key="PlantUMLLanguageExtension" value="false" />
+    </enabledExtensions>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.11 (DrissionPage)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (DrissionPage)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/DrissionPage.iml" filepath="$PROJECT_DIR$/.idea/DrissionPage.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/_units/clicker.py
+++ b/_units/clicker.py
@@ -78,13 +78,12 @@ class Clicker(object):
                     r = self._ele.owner._run_cdp('DOM.getNodeForLocation', x=int(x), y=int(y),
                                                  includeUserAgentShadowDOM=True, ignorePointerEventsNone=True)
                     if r['backendNodeId'] != self._ele._backend_id:
-                        vx, vy = self._ele.rect.viewport_midpoint
+                        vx, vy = self._get_click_coordinates()
                     else:
                         vx, vy = self._ele.rect.viewport_click_point
 
                 except CDPError:
-                    vx, vy = self._ele.rect.viewport_midpoint
-
+                    vx, vy = self._get_click_coordinates()
                 self._click(vx, vy)
                 return self._ele
 
@@ -207,3 +206,8 @@ class Clicker(object):
         self._ele.owner._run_cdp('Input.dispatchMouseEvent', type='mouseReleased', x=view_x,
                                  y=view_y, button=button, _ignore=AlertExistsError)
         return self._ele
+
+    def _get_click_coordinates(self):
+        if self._ele.tag == 'a' and self._ele.attr('href'):
+            return self._ele.rect.viewport_click_point
+        return self._ele.rect.viewport_midpoint

--- a/_units/clicker.pyi
+++ b/_units/clicker.pyi
@@ -145,3 +145,9 @@ class Clicker(object):
         :return: None
         """
         ...
+
+    def _get_click_coordinates(self):
+        """
+        判断点击对象是否为超链接
+        """
+        ...


### PR DESCRIPTION
Fixed the issue where the focus target could not be clicked when the object to be clicked was a hyperlink and there was a line break. The specific reason was that after the line break of some hyperlinks, the viewport_midpoint method was used in clicker, and there was no target element under the coordinate focus located by this method, which would cause the click to be invalid.
The author made a few modifications to the implementation method in clicker.