### PR TITLE
Fix PDF download issue occuring because of newline command in get_pdf function

### DIFF
--- a/DrissionPage/_functions/web.py
+++ b/DrissionPage/_functions/web.py
@@ -249,7 +249,7 @@ def get_pdf(page, path=None, name=None, kwargs=None):
     path = path or '.'
     Path(path).mkdir(parents=True, exist_ok=True)
     name = make_valid_name(name or page.title)
-    with open(f'{path}{sep}{name}.pdf', 'wb', newline='\n') as f:
+    with open(f'{path}{sep}{name}.pdf', 'wb') as f:
         f.write(r)
     return r
 


### PR DESCRIPTION
The save_page function uses get_pdf function which tries to write the file with a newline argument, causing download to not occur. Removing that change fixed that issue and all downloads are working fine