### PR TITLE
fix: write bytes by 'wb', newline is wrong parameter

### DIFF
--- a/DrissionPage/_functions/web.py
+++ b/DrissionPage/_functions/web.py
@@ -249,7 +249,7 @@ def get_pdf(page, path=None, name=None, kwargs=None):
     path = path or '.'
     Path(path).mkdir(parents=True, exist_ok=True)
     name = make_valid_name(name or page.title)
-    with open(f'{path}{sep}{name}.pdf', 'wb', newline='\n') as f:
+    with open(f'{path}{sep}{name}.pdf', 'wb') as f:
         f.write(r)
     return r
 
@@ -316,3 +316,4 @@ def format_headers(txt):
             if name not in (':method', ':scheme', ':authority', ':path'):
                 headers[name] = value
     return headers
+


### PR DESCRIPTION
Traceback (most recent call last):
....
    with open(f'{path}{sep}{name}.pdf', 'wb', newline='\n') as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: binary mode doesn't take a newline argument