### PR TITLE
Fix memory leak caused by `BrowserDriver.BROWSERS` references

### DIFF
--- a/DrissionPage/_base/chromium.py
+++ b/DrissionPage/_base/chromium.py
@@ -236,7 +236,7 @@ class Chromium(object):
     def reconnect(self):
         self._disconnect_flag = True
         self._driver.stop()
-        BrowserDriver.BROWSERS.pop(self.id)
+        BrowserDriver.BROWSERS.pop(self.id, None)
         self._driver = BrowserDriver(self.id, self._ws_address, self)
         self._run_cdp('Target.setDiscoverTargets', discover=True)
         self._driver.set_callback('Target.targetDestroyed', self._onTargetDestroyed)
@@ -440,6 +440,7 @@ class Chromium(object):
     def _on_disconnect(self):
         if not self._disconnect_flag:
             Chromium._BROWSERS.pop(self.id, None)
+            BrowserDriver.BROWSERS.pop(self.id, None)
             if self._chromium_options.is_auto_port and self._chromium_options.user_data_path:
                 path = Path(self._chromium_options.user_data_path)
                 end_time = perf_counter() + 7


### PR DESCRIPTION
### Summary

This PR fixes a memory leak caused by `BrowserDriver.BROWSERS` holding strong references to `BrowserDriver` instances after a `Chromium` instance is closed or disconnected.

### Changes

- In `DrissionPage/_base/chromium.py`, update `Chromium._on_disconnect()` to also remove the corresponding entry from `BrowserDriver.BROWSERS`, ensuring the `BrowserDriver` instance can be garbage collected:
  - `BrowserDriver.BROWSERS.pop(self.id, None)`
- In `Chromium.reconnect()`, change `BrowserDriver.BROWSERS.pop(self.id)` to `BrowserDriver.BROWSERS.pop(self.id, None)` to avoid potential `KeyError` if the entry has already been removed.

### Rationale

- `BrowserDriver.BROWSERS` is a global dictionary that caches `BrowserDriver` instances by browser id.
- Each `BrowserDriver` is stored in this dict during initialization and was not removed on browser shutdown.
- `Chromium.quit()` stops the driver, which triggers `_on_disconnect()`, but previously only `Chromium._BROWSERS` was cleaned up. `BrowserDriver.BROWSERS` retained references, preventing garbage collection and causing memory usage to grow over time when repeatedly creating and closing `Chromium` instances.
- By clearing the corresponding entry in `BrowserDriver.BROWSERS` on disconnect, we release the global reference and avoid the leak.

### Behavior / Compatibility

- Normal usage: no behavior change from the user’s perspective, except improved memory usage over long-running processes.
- Reconnect flow: `Chromium.reconnect()` still discards the old driver and creates a new `BrowserDriver`, but now uses a safe `pop(..., None)` to avoid errors if the entry is already absent.

### How to test

- Repeatedly create and close `Chromium` instances in a loop and observe that `BrowserDriver.BROWSERS` does not grow unbounded and process memory remains stable:

```python
from DrissionPage import Chromium
from DrissionPage._base.driver import BrowserDriver

for i in range(100):
    b = Chromium()
    b.quit()
    print(i, len(BrowserDriver.BROWSERS))
```

- Verify that browser operations (open, navigate, quit, reconnect) still work as expected.
