### PR TITLE
fix: DownloadMission.wait() ignores is_done when timeout is set

### DIFF
--- a/DrissionPage/_units/downloader.py
+++ b/DrissionPage/_units/downloader.py
@@ -276,7 +276,7 @@ class DownloadMission(object):
 
         else:
             end_time = perf_counter() + timeout
-            while perf_counter() < end_time:
+            while not self.is_done and perf_counter() < end_time:  
                 if show:
                     print(f'\r{self.rate}% ', end='')
                 sleep(.2)
@@ -300,3 +300,4 @@ class DownloadMission(object):
             print()
 
         return self.final_path if self.final_path else False
+


### PR DESCRIPTION
When `timeout` is passed to `DownloadMission.wait()`, the while loop only checks
  `perf_counter() < end_time` but does not check `self.is_done`. This causes the
  method to always wait for the full timeout duration even if the download has
  already completed.

  Fix: add `not self.is_done` condition to the loop, consistent with the
  `timeout is None` branch.