### PR TITLE
fix: 修复macOS系统上的组合键问题、退格键问题

### DIFF
--- a/DrissionPage/_functions/keys.py
+++ b/DrissionPage/_functions/keys.py
@@ -12,6 +12,17 @@ from ..errors import AlertExistsError
 modifierBit = {'\ue00a': 1, '\ue009': 2, '\ue03d': 4, '\ue008': 8}
 sys = system().lower()
 
+# macOS Meta(Command) 组合键 → CDP editing commands 映射
+# 参考: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/commands/editor_command_names.h
+_mac_meta_commands = {
+    'a': ['selectAll'],
+    'c': ['copy'],
+    'x': ['cut'],
+    'v': ['paste'],
+    'z': ['undo'],
+    'y': ['redo'],
+}
+
 
 class Keys:
     """特殊按键"""
@@ -378,11 +389,13 @@ def make_input_data(modifiers, key, key_up=False):
     if len(result.get('key', '')) == 1:  # type: ignore
         result['text'] = data['key']
 
-    sys_text = 'windowsVirtualKeyCode' if sys == 'windows' else 'nativeVirtualKeyCode'
+    # CDP 需要同时设置两个虚拟键码字段，否则浏览器无法正确执行编辑命令
     if shift and data.get('shiftKeyCode'):
-        result[sys_text] = data['shiftKeyCode']
+        result['windowsVirtualKeyCode'] = data['shiftKeyCode']
+        result['nativeVirtualKeyCode'] = data['shiftKeyCode']
     elif 'keyCode' in data:
-        result[sys_text] = data['keyCode']
+        result['windowsVirtualKeyCode'] = data['keyCode']
+        result['nativeVirtualKeyCode'] = data['keyCode']
 
     if 'code' in data:
         result['code'] = data['code']
@@ -403,6 +416,14 @@ def make_input_data(modifiers, key, key_up=False):
 
     if modifiers & ~8:
         result['text'] = ''
+
+    # macOS 上 Meta(Command) 组合键需要附加 commands 参数，
+    # 否则 Chrome 会将事件透传给操作系统，触发系统菜单
+    if sys in ('macos', 'darwin') and (modifiers & 4) and not key_up:
+        key_lower = data.get('key', '').lower()
+        cmds = _mac_meta_commands.get(key_lower)
+        if cmds:
+            result['commands'] = cmds
 
     result['type'] = 'keyUp' if key_up else ('keyDown' if result.get('text') else 'rawKeyDown')
     return result

--- a/DrissionPage/_units/actions.py
+++ b/DrissionPage/_units/actions.py
@@ -162,6 +162,10 @@ class Actions:
         key = getattr(Keys, key.upper(), key)
         if key in ('\ue009', '\ue008', '\ue00a', '\ue03d'):  # 如果上修饰符，添加到变量
             self.modifier |= modifierBit.get(key, 0)
+            # 同时发送修饰符的 keyDown 事件给浏览器
+            data = make_input_data(self.modifier, key, False)
+            if data:
+                self.owner._run_cdp('Input.dispatchKeyEvent', **data)
             return self
 
         data = make_input_data(self.modifier, key, False)
@@ -174,6 +178,10 @@ class Actions:
         key = getattr(Keys, key.upper(), key)
         if key in ('\ue009', '\ue008', '\ue00a', '\ue03d'):  # 如果上修饰符，添加到变量
             self.modifier ^= modifierBit.get(key, 0)
+            # 同时发送修饰符的 keyUp 事件给浏览器
+            data = make_input_data(self.modifier, key, True)
+            if data:
+                self.owner._run_cdp('Input.dispatchKeyEvent', **data)
             return self
 
         data = make_input_data(self.modifier, key, True)


### PR DESCRIPTION
#550 
#313 

## Bug 1: windowsVirtualKeyCode 缺失（核心问题）

CDP 的 Input.dispatchKeyEvent 在所有平台上都需要 windowsVirtualKeyCode 才能执行实际的编辑命令（Backspace 删除、全选等）。没有这个字段，事件会被 JS 监听器接收到（keydown 事件触发了），但不会触发浏览器原生编辑行为。

## Bug 2: macOS Meta+Key 缺少 commands 参数
CDP 在 macOS 上收到 modifiers=4 (Meta) 的按键事件时，如果没有 commands 参数（如 ['selectAll']），Chrome 不知道如何处理，会将事件透传给操作系统，从而触发"关于本机"等系统菜单。

修复: 在 make_input_data() 中注入 commands

## Bug 3: 修饰符 key_down / key_up不发送 CDP 事件
key_down(Keys.COMMAND) 只在 Python 内存中设了 self.modifier = 4，不发送任何 CDP 事件给浏览器。

修复: 在设完 bitmask 后也发送一个真实的 dispatchKeyEvent

## 经过测试，以上修改完美解决macOS上全选删除的问题，测试脚本如下：
```python
"""
测试 DrissionPage macOS Cmd+A 全选 + Backspace
注意: 使用 JS 读取 value (而非 attr('value') 只读初始属性)
"""
import time
import tempfile
import os
from DrissionPage import ChromiumPage, ChromiumOptions
from DrissionPage.common import Keys

HTML_CONTENT = """<!DOCTYPE html><html><body style='padding:50px'>
<h2>DrissionPage macOS 快捷键测试</h2>
<input id='t' type='text' value='Hello World 12345' style='width:400px;padding:8px;font-size:16px;'>
<div id='log' style='margin-top:10px;color:#666;font-size:12px;'></div>
<script>
var inp = document.getElementById('t');
var logDiv = document.getElementById('log');
inp.addEventListener('keydown', function(e) {
    logDiv.textContent += 'KD:' + e.key + '(meta:' + e.metaKey + ') ';
});
</script>
</body></html>"""

def main():
    path = os.path.join(tempfile.gettempdir(), "dp_test_final.html")
    with open(path, "w", encoding="utf-8") as f:
        f.write(HTML_CONTENT)

    co = ChromiumOptions()
    co.set_argument("--no-first-run")
    co.set_argument("--no-default-browser-check")
    co.set_browser_path("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
    page = ChromiumPage(co)

    def get_val():
        return page.run_js('return document.getElementById("t").value')

    try:
        page.get(f"file://{path}")
        time.sleep(1)
        inp = page.ele('#t')
        print(f"📝 初始值: '{get_val()}'")

        # 测试1: Backspace 能删除单个字符
        print("\n🧪 测试1: Backspace 删除单个字符")
        inp.click()
        time.sleep(0.3)
        page.actions.type(Keys.BACKSPACE)
        time.sleep(0.3)
        val = get_val()
        print(f"   值: '{val}'")
        ok1 = val == 'Hello World 1234'
        print(f"   {'✅ 通过' if ok1 else '❌ 失败'}")

        # 测试2: Cmd+A 全选 + Backspace 删除全部
        print("\n🧪 测试2: Cmd+A 全选 + Backspace 删除全部")
        page.actions.key_down(Keys.COMMAND).type('a').key_up(Keys.COMMAND)
        time.sleep(0.3)
        log = page.ele('#log').text
        print(f"   Event log: {log}")
        page.actions.type(Keys.BACKSPACE)
        time.sleep(0.3)
        val2 = get_val()
        print(f"   值: '{val2}'")
        ok2 = val2 == ''
        print(f"   {'✅ 通过' if ok2 else '❌ 失败'}")

        # 测试3: type(Keys.CTRL_A) + Backspace
        print("\n🧪 测试3: type(Keys.CTRL_A) + Backspace")
        inp.input('Test Content', clear=True)
        time.sleep(0.3)
        inp.click()
        time.sleep(0.3)
        page.actions.type(Keys.CTRL_A)
        time.sleep(0.3)
        page.actions.type(Keys.BACKSPACE)
        time.sleep(0.3)
        val3 = get_val()
        print(f"   值: '{val3}'")
        ok3 = val3 == ''
        print(f"   {'✅ 通过' if ok3 else '❌ 失败'}")

        # 测试4: 连续 Cmd+A 不弹系统菜单
        print("\n🧪 测试4: 连续 3 次 Cmd+A (观察是否弹出系统菜单)")
        inp.input('ABC123', clear=True)
        time.sleep(0.3)
        inp.click()
        time.sleep(0.3)
        for i in range(3):
            page.actions.key_down(Keys.COMMAND).type('a').key_up(Keys.COMMAND)
            time.sleep(0.3)
            print(f"   第 {i+1} 次完成")
        print("   ⚠️  请观察是否弹出了 macOS 系统窗口")

        print("\n" + "=" * 50)
        all_ok = ok1 and ok2 and ok3
        if all_ok:
            print("🎉 所有测试通过！修复有效！")
        else:
            print("⚠️  部分测试未通过")
        print("=" * 50)

        input("\n按 Enter 关闭浏览器...")

    except Exception as e:
        print(f"❌ 出错: {e}")
        import traceback
        traceback.print_exc()
        input("按 Enter 退出...")
    finally:
        page.quit()

if __name__ == "__main__":
    main()
```