### PR TITLE
bugfix: 过滤chrome://newtab-footer/目标，修复Chrome 146+ 连接错误标签页的问题

### DIFF
--- a/DrissionPage/_pages/chromium_base.py
+++ b/DrissionPage/_pages/chromium_base.py
@@ -85,7 +85,8 @@ class ChromiumBase(BasePage):
                 tabs = self.browser._driver.get(f'http://{self.browser.address}/json').json()
                 _id = 'id'
             tabs = [(i[_id], i['url']) for i in tabs
-                    if i['type'] in ('page', 'webview') and not i['url'].startswith('devtools://')]
+                    if i['type'] in ('page', 'webview') and not i['url'].startswith('devtools://')
+                    and not i['url'].startswith('chrome://newtab-footer')]
             dialog = None
             if len(tabs) > 1:
                 for k, t in enumerate(tabs):


### PR DESCRIPTION
# Chrome 146+ 兼容性修复：连接了错误的标签页

## 问题

在 Chrome 146及更新版本上，页面被挤压到浏览器窗口底部约 100px 的窄条区域内显示。

## 根因

Chrome 146开始将 `chrome://newtab-footer/` 作为一个独立的 CDP `page` 类型目标暴露出来。这是一个渲染在 Chrome 新标签页底部的小型子页面。

当 DrissionPage 枚举可用的页面目标进行连接时，`chrome://newtab-footer/` 与 `chrome://newtab/` 一同出现在目标列表中。取决于 `/json` 端点返回的顺序，DrissionPage 可能会将 footer 子页面选为默认标签页。

当 footer 目标被导航到真实 URL（例如 `https://www.example.com`）时，页面内容会渲染在 footer 的狭小区域内（窗口底部约 100px），而新标签页主页面仍然占据窗口的其余部分。


## 修复方案

在 `DrissionPage/_pages/chromium_base.py` 的 `_connect_browser()` 方法中，从目标列表中过滤掉 footer 子页面：

```python
tabs = [(i[_id], i['url']) for i in tabs
        if i['type'] in ('page', 'webview') 
        and not i['url'].startswith('devtools://')
        and not i['url'].startswith('chrome://newtab-footer')]
```

## Playwright 如何规避此问题

Playwright 从不从现有目标中选择。它通过 `Target.createTarget(url: 'about:blank')` 创建全新页面，并通过 `Browser.setWindowBounds` + `Emulation.setDeviceMetricsOverride` 配合平台特定的 chrome 边框尺寸来显式管理窗口大小（参见 `crPage.ts:_updateViewport()`）。

## 参考资料

- [Chromium Issue 422318935](https://issues.chromium.org/issues/422318935) — 虚拟屏幕变更报告
