### PR TITLE
docs: 修复文档中历史遗留的旧版方法名，修正错别字

### DIFF
--- a/docs_en/ChromiumPage/actions.md
+++ b/docs_en/ChromiumPage/actions.md
@@ -254,7 +254,7 @@ ac.m_click('#div1')
 
 ---
 
-### 📌 `db_click()`
+### 📌 `click(times=2)`
 
 This method is used to double-click the left mouse button, and can be preceded by moving to an element.
 
@@ -265,6 +265,12 @@ This method is used to double-click the left mouse button, and can be preceded b
 | Return Type | Description |
 |:-----------:|-------------|
 | `Actions` | The action chain object itself |
+
+**Example:**
+
+```python
+ac.click('#div1', times=2)
+```
 
 ---
 

--- a/docs_en/ChromiumPage/frame_operation.md
+++ b/docs_en/ChromiumPage/frame_operation.md
@@ -164,16 +164,16 @@ page = WebPage()
 ele = page('Homepage')
 ```
 
-`MixPage` (based on Selenium):
+Traditional Selenium workflow:
 
 ```python
-from DrissionPage import MixPage
+from selenium import webdriver
 
-page = MixPage()
-page.to_frame('#iframeResult')
-page.to_frame('#sss')
-ele = page('Homepage')
-page.to_frame.main()
+driver = webdriver.Chrome()
+driver.switch_to.frame('iframeResult')
+driver.switch_to.frame('sss')
+ele = driver.find_element('xpath', '//*[text()=\"Homepage\"]')
+driver.switch_to.default_content()
 ```
 
 As you can see, the original logic of switching in and out is more cumbersome.

--- a/docs_en/ChromiumPage/get_element_info.md
+++ b/docs_en/ChromiumPage/get_element_info.md
@@ -319,7 +319,7 @@ The save feature is a unique feature of this library, which can directly read fr
 
 For comparison, Selenium cannot save images by itself, often requiring the use of UI tools for assistance, which is not only inefficient and unreliable but also consumes keyboard and mouse resources.
 
-### 📌 `get_src()`
+### 📌 `src()`
 
 This method returns the resource used by the `src` attribute of the element. Base64 data can be returned as `bytes`, while other resources are returned as `str`. If there is no resource, it returns `None`.
 
@@ -339,14 +339,14 @@ For example, you can retrieve the byte data of an image on the page for content 
 
 ```python
 img = page('tag:img')
-src = img.get_src()
+src = img.src()
 ```
 
 ---
 
 ### 📌 `save()`
 
-This method saves the resource obtained from the `get_src()` method to a file.
+This method saves the resource obtained from the `src()` method to a file.
 
 |     Parameter Name    |         Type         |  Default Value  | Description                                     |
 |:---------------------:|:--------------------:|:--------------:|-------------------------------------------------|

--- a/docs_en/ChromiumPage/get_page_info.md
+++ b/docs_en/ChromiumPage/get_page_info.md
@@ -301,30 +301,24 @@ This property returns the page load strategy, which has 3 available options:
 
 ## ✅️️ Cookies and Cache Information
 
-### 📌 `cookies`
+### 📌 `cookies()`
 
-This property returns the cookies used by the current page as a dictionary.
+This method retrieves cookies and returns a `CookiesList` object.
 
-Please note that if different subdomains use the same `name` attribute, the cookies returned by this property may be incomplete.
-
-**Return Type:** `dict`
+You can convert it with `.as_dict()`, `.as_str()`, and `.as_json()`.
 
 ---
 
-### 📌 `get_cookies()`
+### 📌 `cookies()` (options)
 
-This method retrieves cookies and returns them as a list of cookie objects.
+| Parameter Name | Type   | Default | Description |
+|:-------------:|:------:|:-------:|-------------|
+| `all_domains` | `bool` | `False` | Whether to return all cookies. When `False`, only the cookies for the current URL are returned. |
+| `all_info`    | `bool` | `False` | Whether the returned cookies include all information. When `False`, only `name`, `value`, and `domain` are included. |
 
-| Parameter Name | Type   | Default | Description                                                                                   |
-|:-------------:|:------:|:-------:|----------------------------------------------------------------------------------------------|
-| `as_dict`     | `bool` | `False` | Whether to return the results as a dictionary. When `True`, a dictionary of `{name: value}` pairs is returned and the `all_info` parameter is ignored. When `False`, a list of cookie objects is returned. |
-| `all_domains` | `bool` | `False` | Whether to return all cookies. When `False`, only the cookies for the current URL are returned.                                                           |
-| `all_info`    | `bool` | `False` | Whether the returned cookies include all information. When `False`, only `name`, `value`, and `domain` information are included.                                                  |
-
-| Return Type | Description                                        |
-|:------:| -------------------------------------------------- |
-| `dict` | When `as_dict` is `True`, a dictionary of cookies is returned.    |
-| `list` | When `as_dict` is `False`, a list of cookie objects is returned. |
+| Return Type | Description |
+|:------:|-------------|
+| `CookiesList` | Cookie list object. Use `.as_dict()` when a `{name: value}` mapping is needed. |
 
 **Example:**
 
@@ -334,7 +328,7 @@ from DrissionPage import ChromiumPage
 page = ChromiumPage()
 page.get('http://www.baidu.com')
 
-for i in page.get_cookies(as_dict=False):
+for i in page.cookies():
     print(i)
 ```
 
@@ -347,7 +341,7 @@ for i in page.get_cookies(as_dict=False):
 
 ---
 
-### 📌 `get_session_storage()`
+### 📌 `session_storage()`
 
 This method is used to retrieve sessionStorage information, and can retrieve all or a single item.
 
@@ -362,7 +356,7 @@ This method is used to retrieve sessionStorage information, and can retrieve all
 
 ---
 
-### 📌 `get_local_storage()`
+### 📌 `local_storage()`
 
 This method is used to retrieve localStorage information, and can retrieve all or a single item.
 
@@ -377,7 +371,7 @@ This method is used to retrieve localStorage information, and can retrieve all o
 
 ---
 
-## ✅️️ Embeded Objects
+## ✅️️ Embedded Objects
 
 ### 📌 `driver`
 

--- a/docs_en/ChromiumPage/page_operation.md
+++ b/docs_en/ChromiumPage/page_operation.md
@@ -245,7 +245,7 @@ This method is used to execute Chrome DevTools Protocol statements after making 
 
 ## ✅️️ Cookies and Cache
 
-### 📌 `set_cookies()`
+### 📌 `set.cookies()`
 
 This method is used to set cookies.
 
@@ -265,12 +265,12 @@ cookies1 = ['name1=value1', 'name2=value2'],
 cookies2 = ('name1=value1', 'name2=value2', 'secure')
 cookies3 = 'name1=value1; name2=value2; path=/; domain=.example.com; secure'
 cookies4 = {'name1': 'value1', 'name2': 'value2'}
-page.set_cookies(cookies1)
+page.set.cookies(cookies1)
 ```
 
 ---
 
-### 📌 `clear_cookies()`
+### 📌 `set.cookies.clear()`
 
 This method is used to clear all cookies.
 
@@ -280,7 +280,7 @@ This method is used to clear all cookies.
 
 ---
 
-### 📌 `remove_cookies()`
+### 📌 `set.cookies.remove()`
 
 This method is used to delete a cookie.
 
@@ -295,7 +295,7 @@ This method is used to delete a cookie.
 
 ---
 
-### 📌 `set_session_storage()`
+### 📌 `set.session_storage()`
 
 This method is used to set or delete a particular sessionStorage item.
 
@@ -309,12 +309,12 @@ This method is used to set or delete a particular sessionStorage item.
 **Example:**
 
 ```python
-page.set_session_storage(item='abc', value='123')
+page.set.session_storage(item='abc', value='123')
 ```
 
 ---
 
-### 📌 `set_local_storage()`
+### 📌 `set.local_storage()`
 
 This method is used to set or delete a particular localStorage item.
 

--- a/docs_en/ChromiumPage/tab_operation.md
+++ b/docs_en/ChromiumPage/tab_operation.md
@@ -162,9 +162,9 @@ tab = page.get_tab('5399F4ADFE3A27503FFAA56390344EE5')  # Get the object of the 
 
 ---
 
-### 📌 `find_tabs()`
+### 📌 `get_tabs()`
 
-This method is used to find tabs that meet the specified conditions. Only Page objects have this method.
+This method is used to get tabs that meet the specified conditions. Only Page objects have this method.
 
 The `title`, `url`, and `tab_type` parameters are three search conditions, and they are connected with the "and" relationship.
 
@@ -175,12 +175,11 @@ The parameters `title`, `url`, and `tab_type` are connected with the relationshi
 |     `title`    |       `str`       | `None`  | Match tabs that contain this text in the title, match all when `None` |
 |      `url`     |       `str`       | `None`  | Match tabs that contain this text in the URL, match all when `None` |
 |  `tab_type`    | `str`, `list`, `tuple`, `set` | `None` | Match tabs of this type, you can enter multiple types, match all when `None` |
-|    `single`    |       `bool`      |  `True` | If `True`, return the id of the first result; if `False`, return all information |
+|     `as_id`    |       `bool`      |  `False` | If `True`, return tab IDs; if `False`, return tab objects |
 
-|   Return Type  | Description                                            |
-|:--------------:|--------------------------------------------------------|
-|     `str`      | When `single` is `True`, return the tab id               |
-| `List[dict]`   | When `single` is `False`, return all tab information     |
+|   Return Type  | Description |
+|:--------------:|-------------|
+| `list` | A list of tab objects (`as_id=False`) or tab IDs (`as_id=True`) |
 
 **Example:**
 
@@ -192,8 +191,8 @@ from DrissionPage import ChromiumPage
 page = ChromiumPage()
 page.get('https://www.baidu.com')
 
-tab_id = page.find_tabs(url='baidu.com')
-print(tab_id)
+tabs = page.get_tabs(url='baidu.com')
+print(tabs[0].tab_id)
 ```
 
 **Output:**
@@ -202,43 +201,36 @@ print(tab_id)
 '8460E5D55BCA5798AF83BC4D243652A9'
 ```
 
-Get all tab information:
+Get all tab objects:
 
 ```python
-tabs = page.find_tabs(single=False)
-print(tab)
+tabs = page.get_tabs()
+print(tabs)
 ```
 
 **Output:**
 
 ```shell
-[{'description': '',
-  'devtoolsFrontendUrl': '/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/8460E5D55BCA5798AF83BC4D243652A9',
-  'faviconUrl': 'https://www.baidu.com/img/baidu_85beaf5496f291521eb75ba38eacbd87.svg',
-  'id': '8460E5D55BCA5798AF83BC4D243652A9',
-  'title': '百度一下，你就知道',
-  'type': 'page',
-  'url': 'https://www.baidu.com/',
-  'webSocketDebuggerUrl': 'ws://127.0.0.1:9222/devtools/page/8460E5D55BCA5798AF83BC4D243652A9'}]
+[<ChromiumTab browser_id=... tab_id=...>, <ChromiumTab browser_id=... tab_id=...>]
 ```
 
 ---
 
 ### 📌 `latest_tab`
 
-This property returns the id of the last activated tab, which refers to the most recently appeared or newly activated tab.
+This property returns the tab object of the last activated tab, which refers to the most recently appeared or newly activated tab.
 
 Only Page objects have this property.
 
-**Type:** `str`
+**Type:** `ChromiumTab`
 
 **Example:**
 
 ```python
 # Open a tab
 ele.click()
-# Get the object of the latest tab
-tab = page.get_tab(page.latest_tab)  # Equivalent to page.get_tab(0)
+# Get the latest tab object directly
+tab = page.latest_tab
 ```
 
 ---
@@ -340,7 +332,7 @@ Both the Page, Tab, and `ChromiumFrame` objects have this method.
 
 ### 📌 `close_tabs()`
 
-This method is used to close the specified tabs, and multiple tabs can be closed. The current tab is closed by default.
+This method is used to close the specified tabs, and multiple tabs can be closed.
 
 If the closed tabs include the current tab, it will switch to the first remaining tab, but not necessarily the visually first one.
 
@@ -348,8 +340,8 @@ Only the Page object has this method.
 
 |  Parameter Name   |                                                                                                                                              Type                                                                                                                                               | Default Value |                                  Description                                  |
 |:----------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------:|-------------------------------------------------------------------------------|
-|  `tabs_or_ids`   | `str`, `None`, `ChromiumTab`, `List[str, ChromiumTab]`, `Tuple[str, ChromiumTab]`                                                                                                                                                                                                            |     None      | The tab objects or IDs to be processed, can be passed in as a list or tuple, `None` means process the current tab                            |
-|     `others`     |                                                                                                                                               bool                                                                                                                                               |     True      | Whether to close tabs other than the specified ones                                                                                                                                                  |
+|  `tabs_or_ids`   | `str`, `ChromiumTab`, `List[str, ChromiumTab]`, `Tuple[str, ChromiumTab]`                                                                                                                                                                                                            |   Required   | Tab object(s) or tab ID(s) to process |
+|     `others`     | bool | `False` | Whether to close tabs other than the specified ones |
 
 **Returns:** None
 
@@ -357,18 +349,18 @@ Only the Page object has this method.
 
 ```python
 # Close the current tab
-page.close_tabs()
+page.close_tabs(page.tab_id)
 
 # Close the 1st and 3rd tabs
-tabs = page.tabs
+tabs = page.get_tabs()
 page.close_tabs(tabs_or_ids=(tabs[0], tabs[2]))
 ```
 
 ---
 
-### 📌 `close_other_tabs()`
+### 📌 `close_tabs(..., others=True)`
 
-This method is used to close tabs other than the ones passed in, and the current tab is kept by default. Multiple tabs can be passed in.
+Use `close_tabs(..., others=True)` to close tabs other than the passed-in tabs. By default, keep the current tab.
 
 If the closed tabs include the current tab, it will switch to the first remaining tab, but not necessarily the visually first one.
 
@@ -376,7 +368,7 @@ Only the Page object has this method.
 
 |  Parameter Name   |                                                                                                                                              Type                                                                                                                                               | Default Value |                                  Description                                  |
 |:----------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------:|-------------------------------------------------------------------------------|
-|  `tabs_or_ids`   | `str`, `None`, `ChromiumTab`, `List[str, ChromiumTab]`, `Tuple[str, ChromiumTab]`                                                                                                                                                                                                            |     None      | The tab objects or IDs to be processed, can be passed in as a list or tuple, `None` means process the current tab                            |
+|  `tabs_or_ids`   | `str`, `None`, `ChromiumTab`, `List[str, ChromiumTab]`, `Tuple[str, ChromiumTab]`                                                                                                                                                                                                            |     None      | The tabs or IDs to keep. `None` means keep the current tab. |
 
 **Returns:** None
 
@@ -384,29 +376,29 @@ Only the Page object has this method.
 
 ```python
 # Close all tabs except the current tab
-page.close_other_tabs()
+page.close_tabs(page.tab_id, others=True)
 
 # Close all tabs except the first tab
-page.close_other_tabs(page.tab[0])
+page.close_tabs(page.get_tab(1), others=True)
 
 # Close tabs except for specified IDs
 reserve_list = ('0B300BEA6F...', 'B838E91...')
-page.close_other_tabs(reserve_list)
+page.close_tabs(reserve_list, others=True)
 ```
 
 ---
 
 ## ✅️ Activate Tab
 
-### 📌 `set.tab_to_front()`
+### 📌 `activate_tab()`
 
-This method is used to activate a tab and bring it to the front. However, it does not shift the focus to the tab.
+This method is used to activate a tab and bring it to the front.
 
 Only the Page object has this method.
 
-|  Parameter Name |         Type         | Default Value |                               Description                               |
-|:--------------:|:--------------------:|:-------------:|:----------------------------------------------------------------------:|
-|  `tab_or_id`   | `str`, `ChromiumTab`, `None` |     None      | The tab object or ID, the default is `None` which means the current tab |
+|  Parameter Name |         Type         | Default Value | Description |
+|:--------------:|:--------------------:|:-------------:|-------------|
+|  `id_ind_tab`   | `str`, `int`, `ChromiumTab` |  Required  | Tab ID, tab index, or tab object |
 
 **Returns:** None
 
@@ -451,7 +443,7 @@ for link in links[:-1]:
     # Print the title of the tab
     print(new_tab.title)
     # Close all tabs except the list page
-    page.close_other_tabs()
+    page.close_tabs(page.tab_id, others=True)
 ```
 
 

--- a/docs_en/ChromiumPage/waiting.md
+++ b/docs_en/ChromiumPage/waiting.md
@@ -73,28 +73,28 @@ In general, developers don't need to use this method explicitly, as most actions
 
 ---
 
-### 📌 `wait.ele_loaded()`
+### 📌 `wait.eles_loaded()`
 
-This method is used to wait for an element to be loaded in the DOM.
+This method is used to wait for one or more elements to be loaded in the DOM.
 
 Sometimes, the appearance of an element is a prerequisite for the next step of an action. Using this method can prevent inadvertent actions caused by some elements loading slower than the program executes.
 
 | Parameter    | Type                                         | Default | Description                                                |
 |:------------:|:--------------------------------------------:|:-------:| ---------------------------------------------------------- |
-| `locator`    | `str`<br/>`Tuple[str, str]`                   | Required| The element to wait for, specified by locator.              |
+| `locators`   | `str`<br/>`Tuple[str, str]`<br/>`list`<br/>`tuple` | Required| The locator(s) to wait for. |
 | `timeout`    | `float`                                      | `None`  | The timeout duration. If `None`, the page's `timeout` setting will be used. |
+| `any_one`    | `bool`                                       | `False` | If `True`, return success when any locator is loaded. |
 | `raise_err`  | `bool`         | `None`    | Determines whether an error should be raised upon timeout. If `None`, the behavior is determined by `Settings`.          |
 
 | Return Type        | Description                                                |
 |:------------------:| ---------------------------------------------------------- |
-| `ChromiumElement`  | The element object if waiting is successful.               |
-| `False`            | If waiting fails.                                          |
+| `bool`  | Whether waiting succeeded. |
 
 **Example:**
 
 ```python
 ele1.click()  # Click a certain element
-page.wait.ele_loaded('#div1')  # Wait for the element with id 'div1' to load
+page.wait.eles_loaded('#div1')  # Wait for the element with id 'div1' to load
 ele2.click()  # Proceed with the next step after the 'div1' element has finished loading
 ```
 
@@ -463,7 +463,7 @@ page.ele('#button1').click()
 
 ---
 
-### 📌 `wait.disable_or_deleted()`
+### 📌 `wait.disabled_or_deleted()`
 
 This method is used to wait for an element to become disabled or deleted.
 

--- a/docs_en/SessionPage/get_page_info.md
+++ b/docs_en/SessionPage/get_page_info.md
@@ -135,32 +135,24 @@ This property returns the encoding format set by the user.
 
 ## ✅️️ Cookies Information
 
-### 📌 `cookies`
+### 📌 `cookies()`
 
-This property returns the cookies used by the current page as a dictionary.
+This method retrieves cookies and returns a `CookiesList` object.
 
-Note that if different subdomains use the same `name` attribute, the cookies returned by this property may be missing.
-
-**Type:** `dict`
+Note that if different subdomains use the same `name` attribute, conversion to `{name: value}` may overwrite same-name entries.
 
 ---
 
-### 📌 `get_cookies()`
-
-This method retrieves the cookies and returns them in the form of a list of cookies.
-
-**Type:** `dict`, `list`
+### 📌 `cookies()` (options)
 
 | Parameter Name | Type   | Default Value | Description                                                                               |
 |:-------------:|:------:|:-------------:|-------------------------------------------------------------------------------------------|
-| `as_dict`     | `bool` | `False`       | Whether to return the result in dictionary format. When `True`, it returns a `dict` consisting of `{name: value}` key-value pairs, and the `all_info` parameter is invalid. When `False`, it returns a list of cookies. |
 | `all_domains` | `bool` | `False`       | Whether to return cookies of all domains. If `False`, it only returns the cookies of the current domain.                                                       |
 | `all_info`    | `bool` | `False`       | Whether the returned cookies include all information. When `False`, it only includes the `name`, `value`, and `domain` information.                      |
 
-| Return Type | Description                                    |
-|:------:| -------------------------------------------- |
-| `dict` | When `as_dict` is `True`, returns cookies in dictionary format |
-| `list` | When `as_dict` is `False`, returns a list of cookies            |
+| Return Type | Description |
+|:------:|-------------|
+| `CookiesList` | Cookie list object. Use `.as_dict()` when a dictionary is needed. |
 
 **Example:**
 
@@ -171,7 +163,7 @@ page = SessionPage()
 page.get('http://www.baidu.com')
 page.get('http://gitee.com')
 
-for i in page.get_cookies(as_dict=False, all_domains=True):
+for i in page.cookies(all_domains=True):
     print(i)
 ```
 

--- a/docs_en/advance/errors.md
+++ b/docs_en/advance/errors.md
@@ -69,7 +69,7 @@ Thrown when there is an error connecting to the browser.
 
 ### 📌 `NoResourceError`
 
-Thrown when accessing resources fails for the browser element's `get_src()` and `save()` methods.
+Thrown when accessing resources fails for the browser element's `src()` and `save()` methods.
 
 ---
 


### PR DESCRIPTION
在研读说明文档时，发现actions.md、frame_operation.md、get_element_info.md、get_page_info.md、page_operation.md、tab_operation.md、waiting.md 等文件中仍保留了部分旧版方法名示例，与当前源码接口不一致，例如get_src() 实际已更新为 src()，get_cookies()、get_session_storage()、get_local_storage()、find_tabs()、close_other_tabs() 等也已改为新的调用方式。为避免用户按照旧文档编写代码时遇到报错，已批量修正文档中的方法名、示例代码和相关参数说明，使其与当前源码保持一致。
同时，顺手修复了文档中的拼写错误 Embeded -> Embedded，并对部分表述进行了小幅润色，提升文档准确性和可读性。