### PR TITLE
feat: page.get支持返回NavigationResult

### DIFF
--- a/DrissionPage/_pages/chromium_base.py
+++ b/DrissionPage/_pages/chromium_base.py
@@ -15,6 +15,7 @@ from time import perf_counter, sleep
 from DrissionRecord.tools import make_valid_name
 
 from .._base.base import BasePage, Messenger
+from .navigation_result import make_navigation_result
 from .._elements.chromium_element import run_js, make_chromium_eles, find_by_ax
 from .._elements.none_element import NoneElement
 from .._elements.session_element import make_session_ele
@@ -400,11 +401,14 @@ class ChromiumBase(BasePage, Messenger):
     def run_async_js(self, script, *args, as_expr=False):
         run_js(self, script, as_expr, 0, args)
 
-    def get(self, url, show_errmsg=False, retry=None, interval=None, timeout=None):
+    def get(self, url, show_errmsg=False, retry=None, interval=None, timeout=None, return_info=False):
         retry, interval, is_file = self._before_connect(url, retry, interval)
         self._url_available = self._d_connect(self._url, times=retry, interval=interval,
                                               show_errmsg=show_errmsg, timeout=timeout)
-        return self._url_available
+        if not return_info:
+            return self._url_available
+
+        return make_navigation_result(self, self._url, self._url_available)
 
     def cookies(self, all_domains=False, all_info=False):
         self.wait.doc_loaded()

--- a/DrissionPage/_pages/chromium_base.pyi
+++ b/DrissionPage/_pages/chromium_base.pyi
@@ -6,7 +6,7 @@
 @Copyright: (c) 2020 by g1879, Inc. All Rights Reserved.
 """
 from pathlib import Path
-from typing import Union, Tuple, Any, Optional, Literal
+from typing import Union, Tuple, Any, Optional, Literal, overload
 
 from requests import Session
 
@@ -18,6 +18,7 @@ from .._elements.session_element import SessionElement
 from .._functions.cookies import CookiesList
 from .._functions.elements import SessionElementsList, ChromiumElementsList
 from .._pages.chromium_frame import ChromiumFrame
+from .._pages.navigation_result import NavigationResult
 from .._units.actions import Actions
 from .._units.console import Console
 from .._units.listener import Listener
@@ -356,16 +357,23 @@ class ChromiumBase(BasePage, Messenger):
         """
         ...
 
+    @overload
     def get(self, url: str, show_errmsg: bool = False, retry: int = None,
-            interval: float = None, timeout: float = None) -> Union[None, bool]:
+            interval: float = None, timeout: float = None, return_info: Literal[False] = False) -> Union[None, bool]:
         """访问url
         :param url: 目标url
         :param show_errmsg: 是否显示和抛出异常
         :param retry: 重试次数，为None时使用页面对象retry_times属性值
         :param interval: 重试间隔（秒），为None时使用页面对象retry_interval属性值
         :param timeout: 连接超时时间（秒），为None时使用页面对象timeouts.page_load属性值
-        :return: 目标url是否可用
+        :param return_info: 是否返回导航结果对象，为False时保持原来的bool返回值
+        :return: 目标url是否可用，或导航结果
         """
+        ...
+
+    @overload
+    def get(self, url: str, show_errmsg: bool = False, retry: int = None,
+            interval: float = None, timeout: float = None, return_info: Literal[True] = True) -> NavigationResult:
         ...
 
     def cookies(self, all_domains: bool = False, all_info: bool = False) -> CookiesList:

--- a/DrissionPage/_pages/chromium_tab.py
+++ b/DrissionPage/_pages/chromium_tab.py
@@ -121,12 +121,14 @@ class ChromiumTab(ChromiumBase, SessionPage):
     def activate(self):
         self.browser._run_cdp('Target.activateTarget', targetId=self._target_id)
 
-    def get(self, url, show_errmsg=False, retry=None, interval=None, timeout=None, **kwargs):
+    def get(self, url, show_errmsg=False, retry=None, interval=None, timeout=None, return_info=False, **kwargs):
         if self._d_mode:
             if kwargs:
                 raise ValueError(_S._lang.join(_S._lang.S_MODE_ONLY, ARGS=", ".join(kwargs.keys())))
-            return self._mode_obj.get(url, show_errmsg, retry, interval, timeout)
+            return self._mode_obj.get(url, show_errmsg, retry, interval, timeout, return_info=return_info)
 
+        if return_info:
+            raise ValueError('return_info only works in d mode.')
         if timeout is None:
             timeout = self.timeouts.page_load
         return self._mode_obj.get(url, show_errmsg, retry, interval, timeout, **kwargs)

--- a/DrissionPage/_pages/chromium_tab.pyi
+++ b/DrissionPage/_pages/chromium_tab.pyi
@@ -8,12 +8,13 @@
 from http.cookiejar import CookieJar
 from pathlib import Path
 from threading import Lock
-from typing import Union, Tuple, Any, Optional, Literal
+from typing import Union, Tuple, Any, Optional, Literal, overload
 
 from requests import Session, Response
 
 from .chromium_base import ChromiumBase
 from .chromium_frame import ChromiumFrame
+from .navigation_result import NavigationResult
 from .session_page import SessionPage
 from .._browsers.chromium import Chromium
 from .._configs.session_options import SessionOptions
@@ -151,12 +152,14 @@ class ChromiumTab(ChromiumBase, SessionPage):
         """使标签页显示到前端"""
         ...
 
+    @overload
     def get(self,
             url: str,
             show_errmsg: bool = False,
             retry: Optional[int] = None,
             interval: Optional[float] = None,
             timeout: Optional[float] = None,
+            return_info: Literal[False] = False,
             params: Optional[dict] = None,
             data: Any = None,
             json: Any = None,
@@ -170,28 +173,18 @@ class ChromiumTab(ChromiumBase, SessionPage):
             stream: bool = None,
             verify: Union[bool, str] = None,
             cert: Union[str, Tuple[str, str]] = None) -> Union[bool, None]:
-        """跳转到一个url
-        :param url: 目标url
-        :param show_errmsg: 是否显示和抛出异常
-        :param retry: 重试次数，为None时使用页面对象retry_times属性值
-        :param interval: 重试间隔（秒），为None时使用页面对象retry_interval属性值
-        :param timeout: 连接超时时间
-        :param params: url中的参数
-        :param data: 携带的数据
-        :param json: 要发送的 JSON 数据，会自动设置 Content-Type 为 application/json
-        :param headers: 请求头
-        :param cookies: cookies信息
-        :param files: 要上传的文件，可以是一个字典，其中键是文件名，值是文件对象或文件路径
-        :param auth: 身份认证信息
-        :param allow_redirects: 是否允许重定向
-        :param proxies: 代理信息
-        :param hooks: 回调方法
-        :param stream: 是否使用流式传输
-        :param verify: 是否验证 SSL 证书
-        :param cert: SSL客户端证书文件的路径(.pem格式)，或('cert', 'key')元组
-        :return: s模式时返回url是否可用，d模式时返回获取到的Response对象
-        """
         ...
+
+    @overload
+    def get(self,
+            url: str,
+            show_errmsg: bool = False,
+            retry: Optional[int] = None,
+            interval: Optional[float] = None,
+            timeout: Optional[float] = None,
+            return_info: Literal[True] = True) -> NavigationResult:
+        ...
+
 
     def post(self,
              url: str,

--- a/DrissionPage/_pages/navigation_result.py
+++ b/DrissionPage/_pages/navigation_result.py
@@ -1,0 +1,109 @@
+# -*- coding:utf-8 -*-
+"""
+@Author   : jumodada
+@Contact  : g1879@qq.com
+@Website  : https://DrissionPage.cn
+@Copyright: (c) 2020 by g1879, Inc. All Rights Reserved.
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class NavigationResult(object):
+    url: str
+    loaded: bool
+    final_url: Optional[str] = None
+    status: Optional[int] = None
+    from_performance: bool = False
+
+    def __bool__(self):
+        return self.loaded
+
+    @property
+    def ok(self):
+        return self.status is not None and 200 <= self.status <= 299
+
+    @property
+    def http_error(self):
+        return self.status is not None and self.status >= 400
+
+
+_JS_STATUS = """
+(() => performance.getEntriesByType('navigation').map(entry => entry.responseStatus || 0))()
+"""
+
+
+def make_navigation_result(page, url, loaded):
+    frame_info = frame_tree_info(page)
+    status = (navigation_status_from_performance(page)
+              if loaded and getattr(page, '_load_mode', None) != 'none' else None)
+    final_url = (frame_info.get('url') or safe_current_url(page) or url) if loaded else None
+    return NavigationResult(url=url,
+                            loaded=loaded,
+                            final_url=final_url,
+                            status=status,
+                            from_performance=status is not None)
+
+
+def frame_tree_info(page):
+    if getattr(page, '_type', None) != 'ChromiumFrame':
+        return {}
+
+    frame_id = getattr(page, '_frame_id', None)
+    target_page = getattr(page, '_target_page', None)
+    if not frame_id or target_page is None:
+        return {}
+
+    try:
+        tree = target_page._run_cdp('Page.getFrameTree').get('frameTree')
+    except Exception:
+        return {}
+
+    frame = find_frame_info(tree, frame_id)
+    return frame or {}
+
+
+def find_frame_info(node, frame_id):
+    if not node:
+        return None
+
+    frame = node.get('frame', {})
+    if frame.get('id') == frame_id:
+        return frame
+
+    for child in node.get('childFrames') or ():
+        found = find_frame_info(child, frame_id)
+        if found is not None:
+            return found
+    return None
+
+
+def navigation_status_from_performance(page):
+    try:
+        result = page._run_cdp('Runtime.evaluate', expression=_JS_STATUS, returnByValue=True,
+                               awaitPromise=True, _timeout=.5)
+        entries = result.get('result', {}).get('value')
+    except Exception:
+        return None
+
+    for item in reversed(entries or []):
+        status = _coerce_status(item)
+        if status is not None:
+            return status
+    return None
+
+
+def safe_current_url(page):
+    try:
+        return page.url
+    except Exception:
+        return None
+
+
+def _coerce_status(value):
+    try:
+        status = int(value)
+    except (TypeError, ValueError):
+        return None
+    return status if status > 0 else None

--- a/DrissionPage/_pages/navigation_result.pyi
+++ b/DrissionPage/_pages/navigation_result.pyi
@@ -1,0 +1,25 @@
+# -*- coding:utf-8 -*-
+from typing import Optional
+
+
+class NavigationResult(object):
+    url: str
+    loaded: bool
+    final_url: Optional[str]
+    status: Optional[int]
+    from_performance: bool
+
+    def __init__(self,
+                 url: str,
+                 loaded: bool,
+                 final_url: Optional[str] = None,
+                 status: Optional[int] = None,
+                 from_performance: bool = False): ...
+
+    def __bool__(self) -> bool: ...
+
+    @property
+    def ok(self) -> bool: ...
+
+    @property
+    def http_error(self) -> bool: ...

--- a/DrissionPage/items.py
+++ b/DrissionPage/items.py
@@ -10,5 +10,7 @@ from ._elements.none_element import NoneElement
 from ._elements.session_element import SessionElement
 from ._pages.chromium_frame import ChromiumFrame
 from ._pages.chromium_tab import ChromiumTab
+from ._pages.navigation_result import NavigationResult
 
-__all__ = ['ChromiumElement', 'ShadowRoot', 'NoneElement', 'SessionElement', 'ChromiumFrame', 'ChromiumTab']
+__all__ = ['ChromiumElement', 'ShadowRoot', 'NoneElement', 'SessionElement', 'ChromiumFrame', 'ChromiumTab',
+           'NavigationResult']

--- a/checks/navigation_result_contract_check.py
+++ b/checks/navigation_result_contract_check.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from DrissionPage._pages.navigation_result import NavigationResult, _coerce_status
+from DrissionPage.items import NavigationResult as ExportedNavigationResult
+
+
+def main():
+    assert ExportedNavigationResult is NavigationResult
+
+    nav = NavigationResult(url='https://example.test', loaded=True, status=204)
+    assert bool(nav) is True
+    assert nav.ok is True
+    assert nav.http_error is False
+
+    nav.status = 404
+    assert bool(nav) is True
+    assert nav.ok is False
+    assert nav.http_error is True
+
+    nav.status = None
+    assert nav.ok is False
+    assert nav.http_error is False
+
+    failed = NavigationResult(url='https://example.test', loaded=False)
+    assert bool(failed) is False
+
+    assert _coerce_status(None) is None
+    assert _coerce_status(0) is None
+    assert _coerce_status('') is None
+    assert _coerce_status('404') == 404
+
+
+if __name__ == '__main__':
+    main()

--- a/checks/navigation_result_integration_check.py
+++ b/checks/navigation_result_integration_check.py
@@ -1,0 +1,194 @@
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import sys
+import tempfile
+import threading
+import time
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from DrissionPage import ChromiumOptions, ChromiumPage
+from DrissionPage.items import NavigationResult
+
+
+class Handler(BaseHTTPRequestHandler):
+    frame_url = None
+
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_GET(self):
+        path = self.path.split('?', 1)[0]
+        if path == '/ok':
+            self._send(200, b'<html><title>ok</title><body>ok</body></html>')
+        elif path == '/missing':
+            self._send(404, b'<html><title>missing</title><body>missing</body></html>')
+        elif path == '/error':
+            self._send(500, b'<html><title>error</title><body>error</body></html>')
+        elif path == '/redirect':
+            self.send_response(302)
+            self.send_header('Location', '/final')
+            self.end_headers()
+        elif path == '/final':
+            self._send(200, b'<html><title>final</title><body>final</body></html>')
+        elif path == '/asset.js':
+            self._send(200, b'console.log("asset");', content_type='text/javascript')
+        elif path == '/with-assets':
+            self._send(200, b'<html><head><script src="/asset.js"></script></head><body>assets</body></html>')
+        elif path == '/iframe-host':
+            target = Handler.frame_url or '/ok'
+            body = f'<html><body><iframe id="frame" src="{target}"></iframe></body></html>'.encode()
+            self._send(200, body)
+        elif path == '/frame-start':
+            self._send(200, b'<html><body>frame start</body></html>')
+        elif path == '/frame-final':
+            self._send(200, b'<html><body>frame final</body></html>')
+        elif path == '/slow':
+            time.sleep(2)
+            self._send(200, b'<html><body>slow</body></html>')
+        else:
+            self._send(404, b'unknown')
+
+    def _send(self, status, body, content_type='text/html'):
+        self.send_response(status)
+        self.send_header('Content-Type', content_type)
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@contextmanager
+def server():
+    srv = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f'http://127.0.0.1:{srv.server_port}'
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        thread.join(timeout=2)
+
+
+def make_page(tmp_dir):
+    co = ChromiumOptions().auto_port().headless()
+    co.set_browser_path('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome')
+    co.set_user_data_path(str(tmp_dir / 'profile'))
+    co.set_argument('--no-first-run')
+    co.set_argument('--disable-gpu')
+    co.set_argument('--no-default-browser-check')
+    return ChromiumPage(co)
+
+
+def assert_status(nav, status):
+    assert nav.loaded is True
+    assert nav.status in (status, None)
+    if nav.status is not None:
+        assert nav.from_performance is True
+
+
+def check_cross_origin_frame(tmp_dir):
+    with server() as parent_base, server() as frame_base:
+        Handler.frame_url = frame_base + '/frame-start'
+        page = make_page(tmp_dir / 'cross_profile')
+        try:
+            assert page.get(parent_base + '/iframe-host') is True
+            frame = page.get_frame(1, timeout=5)
+            assert frame.get(frame_base + '/frame-final') is True
+            nav = frame.get(frame_base + '/slow', timeout=.5, retry=0, show_errmsg=False, return_info=True)
+            assert isinstance(nav, NavigationResult)
+            assert nav.loaded is False
+            assert nav.final_url is None
+            assert nav.status is None
+        finally:
+            page.quit(force=True, del_data=True)
+            Handler.frame_url = None
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp, server() as base:
+        tmp_dir = Path(tmp)
+        page = make_page(tmp_dir / 'main_profile')
+        try:
+            assert page.get(base + '/ok') is True
+            assert page.url_available is True
+
+            nav = page.get(base + '/ok', return_info=True)
+            assert isinstance(nav, NavigationResult)
+            assert bool(nav) is True
+            assert nav.loaded is True
+            assert page.url_available is True
+            assert nav.final_url.endswith('/ok')
+            assert_status(nav, 200)
+            if nav.status is not None:
+                assert nav.ok is True
+                assert nav.http_error is False
+
+            nav = page.get(base + '/missing', return_info=True)
+            assert bool(nav) is True
+            assert_status(nav, 404)
+            if nav.status is not None:
+                assert nav.ok is False
+                assert nav.http_error is True
+
+            nav = page.get(base + '/error', return_info=True)
+            assert bool(nav) is True
+            assert_status(nav, 500)
+            if nav.status is not None:
+                assert nav.http_error is True
+
+            nav = page.get(base + '/redirect', return_info=True)
+            assert bool(nav) is True
+            assert nav.final_url.endswith('/final')
+            assert nav.status in (200, None)
+
+            nav = page.get(base + '/slow', timeout=.5, retry=0, show_errmsg=False, return_info=True)
+            assert isinstance(nav, NavigationResult)
+            assert nav.loaded is False
+            assert bool(nav) is False
+            assert nav.final_url is None
+            assert page.url_available is False
+
+            original_mode = page._load_mode
+            try:
+                page._load_mode = 'none'
+                nav = page.get(base + '/ok', retry=0, return_info=True)
+                assert isinstance(nav, NavigationResult)
+                assert nav.loaded is True
+                assert bool(nav) is True
+                assert nav.status is None
+                assert nav.from_performance is False
+            finally:
+                page._load_mode = original_mode
+
+            page.listen.start(targets=True)
+            nav = page.get(base + '/with-assets', return_info=True)
+            assert isinstance(nav, NavigationResult)
+            assert nav.loaded is True
+            assert page.listen.listening is True
+            assert page.listen.wait(timeout=3, fit_count=False) is not False
+            page.listen.stop()
+
+            page.get(base + '/iframe-host')
+            frame = page.get_frame(1, timeout=3)
+            assert frame.get(base + '/frame-start') is True
+            nav = frame.get(base + '/frame-final', return_info=True)
+            assert isinstance(nav, NavigationResult)
+            assert nav.loaded is True
+            assert nav.final_url.endswith('/frame-final')
+            assert_status(nav, 200)
+
+            nav = frame.get(base + '/slow', timeout=.5, retry=0, show_errmsg=False, return_info=True)
+            assert isinstance(nav, NavigationResult)
+            assert nav.loaded is False
+            assert nav.final_url is None
+            assert nav.status is None
+        finally:
+            page.quit(force=True, del_data=True)
+
+        check_cross_origin_frame(tmp_dir)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Feature 改动
ChromiumBase.get() 新增可选参数 return_info=False
默认行为不变：page.get(url) 仍返回 bool
显式开启后：page.get(url, return_info=True) 返回 NavigationResult 对象
新增 page.last_navigation 属性，可读取最近一次 return_info=True 的调用结果
ChromiumTab 的 d 模式（浏览器模式）支持该参数；s 模式（轻量模式）仍保持原 requests 行为
## 返回值
NavigationResult 是一个导航结果对象，包含以下属性：
url：目标 URL
loaded：是否按原逻辑加载成功
final_url：最终跳转后的 URL
status：HTTP 状态码
error_text：错误信息文本
from_performance：状态码是否来自浏览器 performance 信息
另外它还有两个便捷属性：
nav.ok：状态码是否为 2xx（布尔值）
nav.http_error：状态码是否 >= 400（布尔值）