### PR TITLE
feat: 新增SSEmessage opt-in SSE监听

### DIFF
--- a/DrissionPage/_units/listener.py
+++ b/DrissionPage/_units/listener.py
@@ -24,11 +24,13 @@ class Listener(object):
         self._running_targets = 0
 
         self._caught = None
+        self._caught_sse = None
         self._request_ids = None
         self._extra_info_ids = None
 
         self.listening = False
         self.tab_id = None
+        self._listen_sse = False
 
         self._targets = True
         self._is_regex = False
@@ -76,6 +78,17 @@ class Listener(object):
                                                ALLOW_TYPE='str, list, tuple, set, True', CURR_TYPE=type(res_type)))
 
     def start(self, targets=None, is_regex=None, method=None, res_type=None):
+        if self._listen_sse:
+            method = ('GET', 'POST') if method is None else method
+            res_type = True if res_type is None else res_type
+        self._listen_sse = False
+        self._start(targets, is_regex, method, res_type)
+
+    def start_sse(self, targets=True, is_regex=None, method='GET'):
+        self._listen_sse = True
+        self._start(targets, is_regex, method, 'EventSource')
+
+    def _start(self, targets=None, is_regex=None, method=None, res_type=None):
         if targets is not None:
             if is_regex is None:
                 is_regex = False
@@ -83,46 +96,66 @@ class Listener(object):
             self.set_targets(targets, is_regex, method, res_type)
         self.clear()
         self.resume()
+        if self._listen_sse:
+            self._owner._set_callback('Network.eventSourceMessageReceived', self._event_source_message_received)
+        else:
+            self._owner._set_callback('Network.eventSourceMessageReceived', None)
         self._owner._run_cdp('Network.enable')
 
     def wait(self, count=1, timeout=None, fit_count=True, raise_err=None):
         if not self.listening:
             raise RuntimeError(_S._lang.join(_S._lang.NOT_LISTENING))
+        return self._wait_queue(self._caught, count, timeout, fit_count, raise_err, _S._lang.DATA_PACKET)
+
+    def wait_sse(self, count=1, timeout=None, fit_count=True, raise_err=None):
+        if not self.listening or not self._listen_sse:
+            raise RuntimeError(_S._lang.join(_S._lang.NOT_LISTENING))
+        return self._wait_queue(self._caught_sse, count, timeout, fit_count, raise_err, 'SSE message')
+
+    def _wait_queue(self, queue, count=1, timeout=None, fit_count=True, raise_err=None, item_name=None):
         success = False
         if not timeout:
-            while self._owner._messenger_running and self.listening and self._caught.qsize() < count:
+            while self._owner._messenger_running and self.listening and queue.qsize() < count:
                 sleep(.02)
             success = self._owner._messenger_running
 
         else:
             end = perf_counter() + timeout
             while self._owner._messenger_running and self.listening and perf_counter() < end:
-                if self._caught.qsize() >= count:
+                if queue.qsize() >= count:
                     success = True
                     break
                 sleep(.02)
 
         if success:
             if count == 1:
-                return self._caught.get_nowait()
-            return [self._caught.get_nowait() for _ in range(count)]
+                return queue.get_nowait()
+            return [queue.get_nowait() for _ in range(count)]
 
-        if fit_count or not self._caught.qsize():
+        if fit_count or not queue.qsize():
             if raise_err is True or (_S.raise_when_wait_failed is True and raise_err is None):
-                raise WaitTimeoutError(_S._lang.join(_S._lang.WAITING_FAILED_, _S._lang.DATA_PACKET, timeout))
+                raise WaitTimeoutError(_S._lang.join(_S._lang.WAITING_FAILED_, item_name, timeout))
             else:
                 return False
         else:
-            return [self._caught.get_nowait() for _ in range(self._caught.qsize())]
+            return [queue.get_nowait() for _ in range(queue.qsize())]
 
     def steps(self, count=None, timeout=None, gap=1):
         if not self.listening:
             raise RuntimeError(_S._lang.join(_S._lang.NOT_LISTENING))
+        yield from self._steps_queue(self._caught, count, timeout, gap)
+
+    def sse_steps(self, count=None, timeout=None, gap=1):
+        if not self.listening or not self._listen_sse:
+            raise RuntimeError(_S._lang.join(_S._lang.NOT_LISTENING))
+        yield from self._steps_queue(self._caught_sse, count, timeout, gap)
+
+    def _steps_queue(self, queue, count=None, timeout=None, gap=1):
         caught = 0
         if timeout is None:
             while self._owner._messenger_running and self.listening:
-                if self._caught.qsize() >= gap:
-                    yield self._caught.get_nowait() if gap == 1 else [self._caught.get_nowait() for _ in range(gap)]
+                if queue.qsize() >= gap:
+                    yield queue.get_nowait() if gap == 1 else [queue.get_nowait() for _ in range(gap)]
                     if count:
                         caught += gap
                         if caught >= count:
@@ -132,8 +165,8 @@ class Listener(object):
         else:
             end = perf_counter() + timeout
             while self._owner._messenger_running and self.listening and perf_counter() < end:
-                if self._caught.qsize() >= gap:
-                    yield self._caught.get_nowait() if gap == 1 else [self._caught.get_nowait() for _ in range(gap)]
+                if queue.qsize() >= gap:
+                    yield queue.get_nowait() if gap == 1 else [queue.get_nowait() for _ in range(gap)]
                     end = perf_counter() + timeout
                     if count:
                         caught += gap
@@ -155,6 +188,7 @@ class Listener(object):
             self._owner._set_callback('Network.loadingFailed', None)
             self._owner._set_callback('Network.requestWillBeSentExtraInfo', None)
             self._owner._set_callback('Network.responseReceivedExtraInfo', None)
+            self._owner._set_callback('Network.eventSourceMessageReceived', None)
             self.listening = False
         if clear:
             self.clear()
@@ -169,6 +203,7 @@ class Listener(object):
         self._request_ids = {}
         self._extra_info_ids = {}
         self._caught = Queue(maxsize=0)
+        self._caught_sse = Queue(maxsize=0)
         self._running_requests = 0
         self._running_targets = 0
 
@@ -194,8 +229,9 @@ class Listener(object):
         self._target_id = target_id
         self._owner = owner
         if self.listening:
+            listen_sse = self._listen_sse
             self.stop()
-            self.start()
+            self.start_sse(targets=None) if listen_sse else self.start()
 
     def _init_callback(self):
         self._owner._set_callback('Network.requestWillBeSent', self._requestWillBeSent)
@@ -204,6 +240,8 @@ class Listener(object):
         self._owner._set_callback('Network.loadingFailed', self._loading_failed)
         self._owner._set_callback('Network.requestWillBeSentExtraInfo', self._requestWillBeSentExtraInfo)
         self._owner._set_callback('Network.responseReceivedExtraInfo', self._responseReceivedExtraInfo)
+        if self._listen_sse:
+            self._owner._set_callback('Network.eventSourceMessageReceived', self._event_source_message_received)
 
     def _requestWillBeSent(self, **kwargs):
         self._running_requests += 1
@@ -256,6 +294,11 @@ class Listener(object):
                 self._extra_info_ids.pop(kwargs['requestId'], None)
             else:
                 r['response'] = kwargs
+
+    def _event_source_message_received(self, **kwargs):
+        packet = self._request_ids.get(kwargs['requestId'], None)
+        if packet:
+            self._caught_sse.put(SSEMessage(packet, kwargs))
 
     def _loading_finished(self, **kwargs):
         self._running_requests -= 1
@@ -330,6 +373,54 @@ class FrameListener(Listener):
         if not self._owner._is_diff_domain and kwargs.get('frameId', None) != self._owner._frame_id:
             return
         super()._response_received(**kwargs)
+
+
+class SSEMessage(object):
+
+    def __init__(self, data_packet, raw_data):
+        self.tab_id = data_packet.tab_id
+        self.target = data_packet.target
+        self._data_packet = data_packet
+        self._raw_data = raw_data
+
+    def __repr__(self):
+        t = f'"{self.target}"' if self.target is not True else True
+        return f'<SSEMessage target={t} eventName="{self.eventName}" data="{self.data}">'
+
+    def __getattr__(self, item):
+        return self._raw_data.get(item, None)
+
+    @property
+    def url(self):
+        return self._data_packet.url
+
+    @property
+    def frameId(self):
+        return self._data_packet.frameId
+
+    @property
+    def requestId(self):
+        return self._raw_data.get('requestId')
+
+    @property
+    def timestamp(self):
+        return self._raw_data.get('timestamp')
+
+    @property
+    def eventName(self):
+        return self._raw_data.get('eventName')
+
+    @property
+    def eventId(self):
+        return self._raw_data.get('eventId')
+
+    @property
+    def data(self):
+        return self._raw_data.get('data')
+
+    @property
+    def raw_data(self):
+        return self._raw_data
 
 
 class DataPacket(object):

--- a/DrissionPage/_units/listener.pyi
+++ b/DrissionPage/_units/listener.pyi
@@ -23,12 +23,14 @@ class Listener(object):
     _method: Union[set, True] = ...
     _res_type: Union[set, True] = ...
     _caught: Optional[Queue] = ...
+    _caught_sse: Optional[Queue] = ...
     _is_regex: bool = ...
     _request_ids: Optional[dict] = ...
     _extra_info_ids: Optional[dict] = ...
     _running_requests: int = ...
     _running_targets: int = ...
     listening: bool = ...
+    _listen_sse: bool = ...
 
     def __init__(self, owner: ChromiumBase):
         """
@@ -71,6 +73,18 @@ class Listener(object):
         """
         ...
 
+    def start_sse(self,
+                  targets: Union[str, list, tuple, set, bool, None] = True,
+                  is_regex: Optional[bool] = None,
+                  method: Union[str, list, tuple, set, bool, None] = 'GET') -> None:
+        """监听EventSource消息，每次监听前清空结果
+        :param targets: 要匹配的EventSource请求url特征，可用list等传入多个，为True时获取所有
+        :param is_regex: 设置的target是否正则表达式，为None时保持原来设置
+        :param method: 设置监听的请求类型，默认'GET'，为True时监听全部
+        :return: None
+        """
+        ...
+
     def wait(self,
              count: int = 1,
              timeout: float = None,
@@ -82,6 +96,32 @@ class Listener(object):
         :param fit_count: 是否必须满足总数要求，发生超时，为True返回False，为False返回已捕捉到的数据包
         :param raise_err: 超时时是否抛出错误，为None时根据Settings设置
         :return: count为1时返回数据包对象，大于1时返回列表，超时且fit_count为True时返回False
+        """
+        ...
+
+    def wait_sse(self,
+                 count: int = 1,
+                 timeout: float = None,
+                 fit_count: bool = True,
+                 raise_err: bool = None) -> Union[List[SSEMessage], SSEMessage, None]:
+        """等待符合要求的EventSource消息到达指定数量
+        :param count: 需要捕捉的消息数量
+        :param timeout: 超时时间（秒），为None无限等待
+        :param fit_count: 是否必须满足总数要求，发生超时，为True返回False，为False返回已捕捉到的消息
+        :param raise_err: 超时时是否抛出错误，为None时根据Settings设置
+        :return: count为1时返回消息对象，大于1时返回列表，超时且fit_count为True时返回False
+        """
+        ...
+
+    def sse_steps(self,
+                  count: int = None,
+                  timeout: float = None,
+                  gap=1) -> Iterable[Union[SSEMessage, List[SSEMessage]]]:
+        """用于单步获取EventSource消息
+        :param count: 需捕获的消息总数，为None表示无限
+        :param timeout: 每个消息等待时间（秒），为None表示无限
+        :param gap: 每接收到多少个消息返回一次数据
+        :return: 用于在接收到监听目标时触发动作的可迭代对象
         """
         ...
 
@@ -146,6 +186,8 @@ class Listener(object):
 
     def _responseReceivedExtraInfo(self, **kwargs) -> None: ...
 
+    def _event_source_message_received(self, **kwargs) -> None: ...
+
     def _loading_finished(self, **kwargs) -> None: ...
 
     def _loading_failed(self, **kwargs) -> None: ...
@@ -159,6 +201,62 @@ class FrameListener(Listener):
         """
         :param owner: ChromiumFrame对象
         """
+        ...
+
+
+class SSEMessage(object):
+    """EventSource消息类"""
+
+    tab_id: str = ...
+    target: str = ...
+    _data_packet: DataPacket = ...
+    _raw_data: dict = ...
+
+    def __init__(self, data_packet: DataPacket, raw_data: dict):
+        """
+        :param data_packet: 产生这个消息的请求数据包
+        :param raw_data: CDP返回的EventSource消息数据
+        """
+        ...
+
+    @property
+    def url(self) -> str:
+        """请求网址"""
+        ...
+
+    @property
+    def frameId(self) -> str:
+        """发出请求的frame id"""
+        ...
+
+    @property
+    def requestId(self) -> str:
+        """请求id"""
+        ...
+
+    @property
+    def timestamp(self) -> float:
+        """消息时间戳"""
+        ...
+
+    @property
+    def eventName(self) -> str:
+        """消息类型"""
+        ...
+
+    @property
+    def eventId(self) -> str:
+        """消息id"""
+        ...
+
+    @property
+    def data(self) -> str:
+        """消息内容"""
+        ...
+
+    @property
+    def raw_data(self) -> dict:
+        """原始消息数据"""
         ...
 
 

--- a/checks/test_listener_sse.py
+++ b/checks/test_listener_sse.py
@@ -1,0 +1,385 @@
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import sys
+from threading import Thread
+from time import perf_counter, sleep
+import unittest
+import warnings
+
+from DrissionPage import Chromium, ChromiumOptions
+from DrissionPage.errors import WaitTimeoutError
+
+
+warnings.filterwarnings('ignore', category=ResourceWarning)
+
+
+class QuietThreadingHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def handle_error(self, request, client_address):
+        error = sys.exc_info()[1]
+        if isinstance(error, (BrokenPipeError, ConnectionResetError, OSError)):
+            return
+        super().handle_error(request, client_address)
+
+
+class SSEHandler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+    child_base = None
+
+    def do_GET(self):
+        path = self.path.split('?', 1)[0]
+
+        pages = {
+            '/page-basic': """
+                <!doctype html><meta charset="utf-8">
+                <script>
+                window.basic = new EventSource('/sse-basic');
+                window.hitApi = () => fetch('/api').then(r => r.json());
+                </script>
+                basic
+            """,
+            '/page-filter': """
+                <!doctype html><meta charset="utf-8">
+                <script>
+                window.target = new EventSource('/sse-target');
+                window.ignore = new EventSource('/sse-ignore');
+                </script>
+                filter
+            """,
+            '/page-multi': """
+                <!doctype html><meta charset="utf-8">
+                <script>
+                window.alpha = new EventSource('/sse-alpha');
+                window.beta = new EventSource('/sse-beta');
+                </script>
+                multi
+            """,
+            '/page-regex': """
+                <!doctype html><meta charset="utf-8">
+                <script>
+                window.regex = new EventSource('/sse-regex-42');
+                window.hitApi = () => fetch('/api').then(r => r.json());
+                </script>
+                regex
+            """,
+            '/page-restart-a': """
+                <!doctype html><meta charset="utf-8">
+                <script>window.restartA = new EventSource('/sse-restart-a');</script>
+                restart-a
+            """,
+            '/page-restart-b': """
+                <!doctype html><meta charset="utf-8">
+                <script>window.restartB = new EventSource('/sse-restart-b');</script>
+                restart-b
+            """,
+            '/page-delayed': """
+                <!doctype html><meta charset="utf-8">
+                <script>window.delayed = new EventSource('/sse-delayed');</script>
+                delayed
+            """,
+            '/page-missing-stream': """
+                <!doctype html><meta charset="utf-8">
+                <script>window.missing = new EventSource('/sse-missing');</script>
+                missing-stream
+            """,
+        }
+
+        if path in pages:
+            self._send_html(pages[path])
+            return
+
+        if path == '/page-iframe':
+            self._send_html(f"""
+                <!doctype html><meta charset="utf-8">
+                <iframe src="{self.child_base}/iframe-child"></iframe>
+                iframe
+            """)
+            return
+
+        if path == '/iframe-child':
+            self._send_html("""
+                <!doctype html><meta charset="utf-8">
+                <script>window.iframeSSE = new EventSource('/sse-iframe');</script>
+                child
+            """)
+            return
+
+        if path == '/api':
+            body = json.dumps({'ok': True, 'text': '普通请求'}, ensure_ascii=False).encode('utf-8')
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json; charset=utf-8')
+            self.send_header('Content-Length', str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        streams = {
+            '/sse-basic': (
+                ('event: greet\nid: 1\ndata: 你好\n\n', 0.05),
+                ('data: world\n\n', 0.05),
+                ('event: done\nid: 2\ndata: 再见\n\n', 0.05),
+            ),
+            '/sse-target': (
+                ('event: target\nid: t1\ndata: target-1\n\n', 0.05),
+                ('event: target\nid: t2\ndata: target-2\n\n', 0.05),
+            ),
+            '/sse-ignore': (
+                ('event: ignore\nid: i1\ndata: ignore-1\n\n', 0.05),
+                ('event: ignore\nid: i2\ndata: ignore-2\n\n', 0.05),
+            ),
+            '/sse-alpha': (('event: alpha\nid: a1\ndata: alpha-1\n\n', 0.05),),
+            '/sse-beta': (('event: beta\nid: b1\ndata: beta-1\n\n', 0.05),),
+            '/sse-regex-42': (('event: regex\nid: r1\ndata: regex-ok\n\n', 0.05),),
+            '/sse-restart-a': (('event: restart\nid: old\ndata: restart-a\n\n', 0.05),),
+            '/sse-restart-b': (('event: restart\nid: new\ndata: restart-b\n\n', 0.05),),
+            '/sse-delayed': (
+                ('event: delayed\nid: d1\ndata: delayed-1\n\n', 1.0),
+                ('event: delayed\nid: d2\ndata: delayed-2\n\n', 0.05),
+            ),
+            '/sse-iframe': (('event: iframe\nid: f1\ndata: iframe-ok\n\n', 0.05),),
+        }
+
+        if path in streams:
+            self._send_sse(streams[path])
+            return
+
+        self.send_response(404)
+        self.send_header('Content-Length', '0')
+        self.end_headers()
+
+    def _send_html(self, html):
+        body = html.encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_sse(self, chunks):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/event-stream; charset=utf-8')
+        self.send_header('Cache-Control', 'no-cache')
+        self.send_header('Connection', 'keep-alive')
+        self.end_headers()
+        try:
+            for chunk, delay_after in chunks:
+                self.wfile.write(chunk.encode('utf-8'))
+                self.wfile.flush()
+                sleep(delay_after)
+
+            end = perf_counter() + 1.5
+            while perf_counter() < end:
+                self.wfile.write(b': keepalive\n\n')
+                self.wfile.flush()
+                sleep(0.5)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass
+
+    def log_message(self, *_):
+        pass
+
+
+@contextmanager
+def local_server(handler=SSEHandler):
+    server = QuietThreadingHTTPServer(('127.0.0.1', 0), handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f'http://127.0.0.1:{server.server_port}'
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@contextmanager
+def make_tab():
+    co = ChromiumOptions(read_file=False)
+    co.auto_port()
+    co.headless(True)
+    co.set_load_mode('normal')
+    co.set_argument('--no-sandbox')
+    co.set_argument('--disable-gpu')
+    browser = Chromium(addr_or_opts=co)
+    try:
+        yield browser.latest_tab
+    finally:
+        browser.quit()
+
+
+class TestListenerSSE(unittest.TestCase):
+    def test_wait_sse_receives_event_fields_utf8_and_raw_data(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse('/sse-basic')
+            self.assertTrue(page.get(base + '/page-basic'))
+
+            first = page.listen.wait_sse(timeout=5)
+            second = page.listen.wait_sse(timeout=5)
+
+            self.assertEqual(first.url, base + '/sse-basic')
+            self.assertEqual(first.eventName, 'greet')
+            self.assertEqual(first.eventId, '1')
+            self.assertEqual(first.data, '你好')
+            self.assertEqual(second.eventName, 'message')
+            self.assertEqual(second.data, 'world')
+            self.assertEqual(first.requestId, second.requestId)
+            self.assertIsInstance(first.timestamp, float)
+            self.assertEqual(first.raw_data['data'], '你好')
+            self.assertIsNone(first.not_a_cdp_field)
+            self.assertIn('SSEMessage', repr(first))
+
+    def test_wait_sse_count_returns_ordered_message_list(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse('/sse-basic')
+            self.assertTrue(page.get(base + '/page-basic'))
+
+            messages = page.listen.wait_sse(count=3, timeout=5)
+
+            self.assertEqual([m.data for m in messages], ['你好', 'world', '再见'])
+            self.assertEqual([m.eventName for m in messages], ['greet', 'message', 'done'])
+
+    def test_sse_steps_returns_gap_batches(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse('/sse-basic')
+            self.assertTrue(page.get(base + '/page-basic'))
+
+            batch = next(page.listen.sse_steps(count=2, timeout=5, gap=2))
+
+            self.assertEqual([m.data for m in batch], ['你好', 'world'])
+
+    def test_start_sse_filters_single_target(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse('/sse-target')
+            self.assertTrue(page.get(base + '/page-filter'))
+
+            messages = page.listen.wait_sse(count=2, timeout=5)
+
+            self.assertEqual([m.data for m in messages], ['target-1', 'target-2'])
+            self.assertTrue(all('/sse-target' in m.url for m in messages))
+            self.assertTrue(all(m.eventName == 'target' for m in messages))
+
+    def test_start_sse_accepts_multiple_targets(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse(('/sse-alpha', '/sse-beta'))
+            self.assertTrue(page.get(base + '/page-multi'))
+
+            messages = page.listen.wait_sse(count=2, timeout=5)
+
+            self.assertEqual({m.data for m in messages}, {'alpha-1', 'beta-1'})
+            self.assertEqual({m.eventName for m in messages}, {'alpha', 'beta'})
+
+    def test_start_sse_targets_true_captures_all_event_sources(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse(True)
+            self.assertTrue(page.get(base + '/page-filter'))
+
+            messages = page.listen.wait_sse(count=4, timeout=5)
+
+            self.assertEqual(
+                {m.data for m in messages},
+                {'target-1', 'target-2', 'ignore-1', 'ignore-2'},
+            )
+
+    def test_start_sse_accepts_regex_target(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse(r'/sse-regex-\d+', is_regex=True)
+            self.assertTrue(page.get(base + '/page-regex'))
+
+            message = page.listen.wait_sse(timeout=5)
+
+            self.assertEqual(message.data, 'regex-ok')
+            self.assertEqual(message.eventId, 'r1')
+
+    def test_start_sse_restarts_and_clears_previous_queue(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse('/sse-restart-a')
+            self.assertTrue(page.get(base + '/page-restart-a'))
+            page.listen.wait_sse(timeout=5)
+
+            page.listen.start_sse('/sse-restart-b')
+            self.assertTrue(page.get(base + '/page-restart-b'))
+            message = page.listen.wait_sse(timeout=5)
+
+            self.assertEqual(message.data, 'restart-b')
+            self.assertFalse(page.listen.wait_sse(timeout=0.3))
+
+    def test_wait_sse_fit_count_false_returns_partial_messages(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse('/sse-delayed')
+            self.assertTrue(page.get(base + '/page-delayed'))
+
+            messages = page.listen.wait_sse(count=2, timeout=0.4, fit_count=False)
+
+            self.assertEqual([m.data for m in messages], ['delayed-1'])
+
+    def test_wait_sse_timeout_returns_false_when_no_message_arrives(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse('/sse-missing')
+            self.assertTrue(page.get(base + '/page-missing-stream'))
+
+            self.assertFalse(page.listen.wait_sse(timeout=0.5))
+
+    def test_wait_sse_raise_err_raises_wait_timeout_error(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse('/sse-missing')
+            self.assertTrue(page.get(base + '/page-missing-stream'))
+
+            with self.assertRaises(WaitTimeoutError):
+                page.listen.wait_sse(timeout=0.5, raise_err=True)
+
+    def test_wait_sse_requires_sse_mode(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start('/api')
+            self.assertTrue(page.get(base + '/page-basic'))
+
+            with self.assertRaises(RuntimeError):
+                page.listen.wait_sse(timeout=0.2)
+
+    def test_pause_clear_makes_wait_sse_unavailable_until_restarted(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse('/sse-basic')
+            page.listen.pause(clear=True)
+            self.assertTrue(page.get(base + '/page-basic'))
+
+            with self.assertRaises(RuntimeError):
+                page.listen.wait_sse(timeout=0.2)
+
+            page.listen.start_sse('/sse-basic')
+            self.assertTrue(page.get(base + '/page-basic'))
+            self.assertEqual(page.listen.wait_sse(timeout=5).data, '你好')
+
+    def test_normal_listener_still_returns_datapacket_after_sse(self):
+        with local_server() as base, make_tab() as page:
+            page.listen.start_sse(r'/sse-regex-\d+', is_regex=True)
+            self.assertTrue(page.get(base + '/page-regex'))
+            self.assertEqual(page.listen.wait_sse(timeout=5).data, 'regex-ok')
+
+            page.listen.stop()
+            page.listen.start('/api')
+            page.run_js('return window.hitApi();')
+            packet = page.listen.wait(timeout=5)
+
+            self.assertEqual(packet.url, base + '/api')
+            self.assertEqual(packet.response.body, {'ok': True, 'text': '普通请求'})
+
+    def test_tab_listener_captures_cross_origin_iframe_sse(self):
+        with local_server() as child_base:
+            class ParentHandler(SSEHandler):
+                pass
+
+            ParentHandler.child_base = child_base
+
+            with local_server(ParentHandler) as parent_base, make_tab() as page:
+                page.listen.start_sse('/sse-iframe')
+                self.assertTrue(page.get(parent_base + '/page-iframe'))
+
+                message = page.listen.wait_sse(timeout=5)
+
+                self.assertEqual(message.data, 'iframe-ok')
+                self.assertEqual(message.eventName, 'iframe')
+                self.assertTrue(message.url.startswith(child_base))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2, warnings='ignore')


### PR DESCRIPTION
新增 opt-in SSE/EventSource 监听
```
page.listen.start_sse('/sse')
msg = page.listen.wait_sse(timeout=5)
print(msg.eventName, msg.eventId, msg.data)

for msg in page.listen.sse_steps(timeout=5):
.....
```

新增返回对象SSEMessage
字段包含

```
msg.url
msg.frameId
msg.eventName
msg.eventId
msg.data
msg.raw_data
msg.requestId
msg.timestamp
```