### PR TITLE
fix: WS/SSE Listener 契约修复

### DIFF
--- a/DrissionPage/_units/listener.py
+++ b/DrissionPage/_units/listener.py
@@ -70,6 +70,9 @@ class BaseListener(object):
 
 
 class Listener(BaseListener):
+    _WEBSOCKET_METHOD = 'GET'
+    _WEBSOCKET_RESOURCE_TYPE = 'WebSocket'
+
     def __init__(self, owner):
         super().__init__(owner)
         self._caught = None
@@ -323,7 +326,7 @@ class Listener(BaseListener):
             self._caught.put(p)
 
     def _webSocketCreated(self, **kwargs):
-        target = in_targets(self, kwargs['url'], True, True)
+        target = in_targets(self, kwargs['url'], self._WEBSOCKET_METHOD, self._WEBSOCKET_RESOURCE_TYPE)
         if target:
             self._ws_info[kwargs['requestId']] = WebSocketConnectInfo(self._owner, target, kwargs['requestId'],
                                                                       kwargs['url'], kwargs.get('initiator'))
@@ -828,6 +831,14 @@ class WebSocketPacket(object):
         return self._payload
 
     @property
+    def payload(self):
+        return self.data
+
+    @property
+    def connect_info(self):
+        return self._connect_info
+
+    @property
     def url(self):
         return self._connect_info.url if self._connect_info else None
 
@@ -882,6 +893,10 @@ class SSEPacket(object):
     @property
     def data(self):
         return self._raw_data['data']
+
+    @property
+    def connect_info(self):
+        return self._connect_info
 
     @property
     def url(self):

--- a/DrissionPage/_units/listener.pyi
+++ b/DrissionPage/_units/listener.pyi
@@ -562,6 +562,16 @@ class WebSocketPacket(object):
         ...
 
     @property
+    def payload(self) -> Union[dict, bytes, str]:
+        """数据包内容"""
+        ...
+
+    @property
+    def connect_info(self) -> Optional[WebSocketConnectInfo]:
+        """连接信息（如有）"""
+        ...
+
+    @property
     def url(self) -> Optional[str]:
         """触发数据包的请求的url"""
         ...
@@ -626,6 +636,11 @@ class SSEPacket(object):
     @property
     def data(self) -> str:
         """数据包数据"""
+        ...
+
+    @property
+    def connect_info(self) -> Optional[DataPacket]:
+        """连接信息（如有）"""
         ...
 
     @property


### PR DESCRIPTION
## 问题
无 URL 目标过滤时，监听器可以收到部分 `WebSocketPacket`。但设置 URL 目标过滤后，实际结果是无法稳定获得匹配 `/ws` 的 `WebSocketPacket`。

## 原因
是WebSocket 创建事件的目标匹配使用了错误的过滤参数：

```python
target = in_targets(self, kwargs['url'], True, True)
```

`in_targets()` 同时检查 URL、HTTP method 和 resource type。当前 listener 的默认 method 集合通常是 `{'GET', 'POST'}`，resource type 在 WebSocket-only 模式下是 `{'WebSocket'}`。传入布尔值 `True` 会导致 method/resource type 维度无法与当前过滤集合匹配，从而使带 URL 目标过滤的 WebSocket 连接没有正确写入 `_ws_info`。

## 修复
业务包作为主返回对象，连接信息作为元数据挂载，按照文档说明契约进行修复

## 回归风险点：均已通过测试
- HTTP监听
- WebSocket监听
- SSE 消息