### PR TITLE
fix: 避免显式定位符误走文本兜底

### DIFF
--- a/DrissionPage/_functions/locator.py
+++ b/DrissionPage/_functions/locator.py
@@ -83,8 +83,9 @@ def _get_arg(text) -> list:
 
 
 def is_str_loc(text):
-    return text.startswith(('.', '#', '@', 't:', 't=', 'tag:', 'tag=', 'tx:', 'tx=', 'tx^', 'tx$', 'text:', 'text=',
-                            'text^', 'text$', 'xpath:', 'xpath=', 'x:', 'x=', 'css:', 'css=', 'c:', 'c='))
+    return text.startswith(('/', '.', '#', '@', 't:', 't=', 'tag:', 'tag=', 'tx:', 'tx=', 'tx^', 'tx$',
+                            'text:', 'text=', 'text^', 'text$', 'xpath:', 'xpath=', 'x:', 'x=', 'css:',
+                            'css=', 'c:', 'c='))
 
 
 def is_selenium_loc(loc):
@@ -146,10 +147,17 @@ def str_to_ax_loc(loc):
 
 def str_to_xpath_loc(loc):
     loc_by = 'xpath'
+    if loc.startswith(('/', './', '../')):
+        return loc_by, loc
     loc = _preprocess(loc)
 
+    # 纯 . / # 开头按 css selector 查找，.=/.:/.^/.$ 和 #=/#:/#^/#$ 已在 _preprocess() 中转为 DP 属性语法
+    if loc.startswith(('.', '#')):
+        loc_by = 'css selector'
+        loc_str = loc
+
     # 多属性查找
-    if loc.startswith(('@@', '@|', '@!')) and loc not in ('@@', '@|', '@!'):
+    elif loc.startswith(('@@', '@|', '@!')) and loc not in ('@@', '@|', '@!'):
         loc_str = _make_multi_xpath_str('*', loc)[1]
 
     # 单属性查找

--- a/DrissionPage/_pages/chromium_base.py
+++ b/DrissionPage/_pages/chromium_base.py
@@ -470,8 +470,11 @@ class ChromiumBase(BasePage, Messenger):
             bid = self._run_cdp('Accessibility.getRootAXNode', frameId=self._frame_id)['node']['backendDOMNodeId']
             return find_by_ax(self, bid, loc, index, timeout)
 
-        else:
+        elif mode == 'any':
             return find_by_any(self, loc, index, timeout)
+
+        else:
+            return find_by_syntax(self, loc, index, timeout)
 
     def refresh(self, ignore_cache=False):
         self._is_loading = True
@@ -914,41 +917,66 @@ class Alert(object):
         self.auto = auto
 
 
+def find_by_syntax(page, loc, index, timeout):
+    return wait_for_ele(do_find_syntax, target=page, timeout=timeout, index=index, page=page, loc=loc, ind=index)
+
+
 def do_find_syntax(page, loc, ind):
     r = page._run_cdp('DOM.performSearch', query=loc, includeUserAgentShadowDOM=True, _ignore=True)
     searchId = r.get('searchId')
-    resultCount = r.get('resultCount')
-    if not resultCount or (ind and resultCount < abs(ind)):
-        page._run_cdp('DOM.discardSearchResults', searchId=searchId, _timeout=0, _ignore=True)
+    if not searchId:
         return None
+    resultCount = r.get('resultCount') or 0
 
-    r = page._run_cdp('DOM.getSearchResults', searchId=searchId, _ignore=True,
-                      fromIndex=0, toIndex=resultCount).get('nodeIds')
-    if not r or not r[0]:
-        return None
+    def get_node_ids(from_index, to_index):
+        ids = page._run_cdp('DOM.getSearchResults', searchId=searchId, _ignore=True,
+                            fromIndex=from_index, toIndex=to_index).get('nodeIds')
+        return [i for i in ids or () if i]
 
-    if ind is None:
-        r = make_chromium_eles(page, _ids=r, index=None, id_type='node_id', ele_only=True)
+    def get_ele(node_id):
+        ele = make_chromium_eles(page, _ids=node_id, id_type='node_id', ele_only=True)
+        return None if ele is False else ele
 
-    else:
-        eles = []
-        got = 0
-        for i in r:
-            n = page._run_cdp('DOM.describeNode', _ignore=True, nodeId=i).get('node')
-            if not n:
-                page._run_cdp('DOM.discardSearchResults', searchId=searchId, _timeout=0, _ignore=True)
-                return None
-            if n['nodeName'] not in ('#text', '#comment'):
-                eles.append(i)
-                got += 1
-                if (0 < ind == got) or (not ind and got == 1):
-                    break
-        if not got:
+    try:
+        if not resultCount:
             return None
-        r = make_chromium_eles(page, _ids=eles, index=ind, id_type='node_id')
 
-    page._run_cdp('DOM.discardSearchResults', searchId=searchId, _timeout=0, _ignore=True)
-    return None if r is False else r
+        if ind is None:
+            r = make_chromium_eles(page, _ids=get_node_ids(0, resultCount), index=None,
+                                   id_type='node_id', ele_only=True)
+            return None if r is False or not r else r
+
+        if ind < 0:
+            to_index = resultCount
+            left = -ind
+            while to_index > 0:
+                from_index = max(to_index - 50, 0)
+                for node_id in reversed(get_node_ids(from_index, to_index)):
+                    ele = get_ele(node_id)
+                    if ele is None:
+                        continue
+                    left -= 1
+                    if left == 0:
+                        return ele
+                to_index = from_index
+            return None
+
+        from_index = 0
+        left = ind or 1
+        while from_index < resultCount:
+            to_index = min(from_index + 50, resultCount)
+            for node_id in get_node_ids(from_index, to_index):
+                ele = get_ele(node_id)
+                if ele is None:
+                    continue
+                left -= 1
+                if left == 0:
+                    return ele
+            from_index = to_index
+        return None
+
+    finally:
+        page._run_cdp('DOM.discardSearchResults', searchId=searchId, _timeout=0, _ignore=True)
 
 
 def find_by_any(page, loc, index, timeout):


### PR DESCRIPTION
显式 xpath/css 语法找不到目标时不应继续按 any 文本搜索，否则页面文本包含定位符片段时会返回错误元素。5.0.0b0 还声明纯 . / # 开头按 CSS 匹配，因此同步补齐该解析边界，保留 .:/#= 等 DP 属性语法。