### PR TITLE
fix: get_frames 默认 XPath 扩展支持 object 帧元素

### DIFF
--- a/DrissionPage/_pages/chromium_base.py
+++ b/DrissionPage/_pages/chromium_base.py
@@ -591,7 +591,7 @@ class ChromiumBase(BasePage, Messenger):
         return NoneElement(self, 'get_frame()', args={'loc_ind_ele': loc_ind_ele, 'timeout': timeout})
 
     def get_frames(self, locator=None, timeout=None):
-        locator = locator or 'xpath://*[name()="iframe" or name()="frame"]'
+        locator = locator or 'xpath://*[name()="iframe" or name()="frame" or name()="object"]'
         return ChromiumElementsList(self, self._ele(locator, timeout=timeout, index=None, raise_err=False))
 
     def session_storage(self, item=None):


### PR DESCRIPTION
底层解析tag:object已可产出ChromiumFrame对象，但get_frames内置默认选择器仅检索iframe、frame标签，造成<object>类型内嵌帧在默认查询场景被遗漏